### PR TITLE
Verify one small function

### DIFF
--- a/curve25519-dalek/src/backend/serial/u64/scalar_verus.rs
+++ b/curve25519-dalek/src/backend/serial/u64/scalar_verus.rs
@@ -437,7 +437,7 @@ verus! {
                     (2u64 << 52) as int + 10 <= (2u64 << 53) as int
                 ) by (compute_only);
             }
-            borrow = a.limbs[i].wrapping_sub(b.limbs[i] + borrow >> 63);
+            borrow = a.limbs[i].wrapping_sub(b.limbs[i] + (borrow >> 63));
             difference.limbs[i] = borrow & mask;
         }
 

--- a/curve25519-dalek/src/backend/serial/u64/scalar_verus.rs
+++ b/curve25519-dalek/src/backend/serial/u64/scalar_verus.rs
@@ -176,6 +176,7 @@ verus! {
                 assert(1u128 << 52 == 1u64 << 52) by (bit_vector);
                 assert((x as u128) < (1u128 << 52));
                 assert((y as u128) < (1u128 << 52));
+                // Start here AI
                 assert((x as u128) * (y as u128) <= (x as u128) * (1u128 << 52)) by
                   {
                     if x > 0
@@ -190,6 +191,7 @@ verus! {
                 assert((x as u128) * (1u128 << 52) < (1u128 << 52) * (1u128 << 52)) by
                   {lemma_mul_strict_inequality(x as int, (1u128 << 52) as int, (1u128 << 52) as int)};
                 assert((1u128 << 52) * (1u128 << 52) == (1u128 << 104)) by (compute);
+                // Finish here AI
             }
             (x as u128) * (y as u128)
         }

--- a/curve25519-dalek/src/backend/serial/u64/scalar_verus.rs
+++ b/curve25519-dalek/src/backend/serial/u64/scalar_verus.rs
@@ -169,6 +169,7 @@ verus! {
             y < (1u64 << 52),
         ensures 
             z < (1u128 << 104),
+            z == x * y
         {
             proof {
                 assert(x < (1u64 << 52));

--- a/curve25519-dalek/src/backend/serial/u64/scalar_verus.rs
+++ b/curve25519-dalek/src/backend/serial/u64/scalar_verus.rs
@@ -1,7 +1,6 @@
 // scalar64_verus.rs
 #![allow(unused)]
 use vstd::prelude::*;
-use vstd::arithmetic::mul::lemma_mul_by_zero_is_zero;
 use vstd::arithmetic::mul::lemma_mul_strict_inequality;
 use vstd::calc;
 use vstd::arithmetic::power2::*;
@@ -178,6 +177,7 @@ verus! {
                 assert((x as u128) < (1u128 << 52));
                 assert((x as u128) * (1u128 << 52) < (1u128 << 52) * (1u128 << 52)) by
                   {lemma_mul_strict_inequality(x as int, (1u128 << 52) as int, (1u128 << 52) as int)};
+                assert((y as u128) < (1u128 << 52));
                 assert((x as u128) * (y as u128) <= (x as u128) * (1u128 << 52)) by
                   {
 
@@ -186,8 +186,8 @@ verus! {
                       lemma_mul_strict_inequality(y as int, (1u128 << 52) as int, x as int)
                     } else {
                         assert (x == 0);
-                        assert ((x as u128) * (y as u128) == 0) by {lemma_mul_by_zero_is_zero(x as int)};
-                        assert ((x as u128) * (1u128 << 52) == 0) by {lemma_mul_by_zero_is_zero(x as int)};
+                        assert ((x as u128) * (y as u128) == 0);
+                        assert ((x as u128) * (1u128 << 52) == 0);
                     }
                   };
                 assert((x as u128) * (y as u128) < (1u128 << 52) * (1u128 << 52));

--- a/curve25519-dalek/src/backend/serial/u64/scalar_verus.rs
+++ b/curve25519-dalek/src/backend/serial/u64/scalar_verus.rs
@@ -189,7 +189,6 @@ verus! {
                         assert ((x as u128) * (1u128 << 52) == 0);
                     }
                   };
-                assert((x as u128) * (y as u128) < (1u128 << 52) * (1u128 << 52));
                 assert((1u128 << 52) * (1u128 << 52) == (1u128 << 104)) by (compute);
             }
             (x as u128) * (y as u128)

--- a/curve25519-dalek/src/backend/serial/u64/scalar_verus.rs
+++ b/curve25519-dalek/src/backend/serial/u64/scalar_verus.rs
@@ -1,6 +1,7 @@
 // scalar64_verus.rs
 #![allow(unused)]
 use vstd::prelude::*;
+use vstd::arithmetic::mul::lemma_mul_strict_inequality;
 use vstd::calc;
 use vstd::arithmetic::power2::*;
 use subtle::{Choice, ConditionallySelectable};
@@ -178,10 +179,14 @@ verus! {
                 assert((y as u128) == y as u64); 
                 assert(1u128 << 52 == 1u64 << 52) by (bit_vector);
                 assert((x as u128) < (1u128 << 52));
+                assert((x as u128) * (1u128 << 52) < (1u128 << 52) * (1u128 << 52)) by
+                  {lemma_mul_strict_inequality(x as int, (1u128 << 52) as int, (1u128 << 52) as int)};
                 assert((y as u128) < (1u128 << 52));
-                assert((1u128 << 52) * (1u128 << 52) < u128::MAX) by (bit_vector);
-                assume((x as u128) * (y as u128) < (1u128 << 52) * (1u128 << 52)); 
-                assume((1u128 << 52) * (1u128 << 52) < (1u128 << 104)); // by (nonlinear_arith);
+                assume (x > 0);
+                assert((x as u128) * (y as u128) < (x as u128) * (1u128 << 52)) by
+                  {lemma_mul_strict_inequality(y as int, (1u128 << 52) as int, x as int)};
+                assert((x as u128) * (y as u128) < (1u128 << 52) * (1u128 << 52));
+                assert((1u128 << 52) * (1u128 << 52) <= (1u128 << 104)) by (compute);
                 assert((x as u128) * (y as u128) < (1u128 << 104));
             }
             (x as u128) * (y as u128)

--- a/curve25519-dalek/src/backend/serial/u64/scalar_verus.rs
+++ b/curve25519-dalek/src/backend/serial/u64/scalar_verus.rs
@@ -190,11 +190,9 @@ verus! {
                     (x as u128) * (1u128 << 52); (<) {
                         lemma_mul_strict_inequality(x as int, (1u128 << 52) as int, (1u128 << 52) as int);
                     }
-                    (1u128 << 52) * (1u128 << 52); (==) {
-                        assert((1u128 << 52) * (1u128 << 52) == (1u128 << 104)) by (compute);
-                    }
-                    (1u128 << 104) as int;
+                    (1u128 << 52) * (1u128 << 52);
                 }
+                assert((1u128 << 52) * (1u128 << 52) == (1u128 << 104)) by (compute);
             }
             (x as u128) * (y as u128)
         }

--- a/curve25519-dalek/src/backend/serial/u64/scalar_verus.rs
+++ b/curve25519-dalek/src/backend/serial/u64/scalar_verus.rs
@@ -414,7 +414,7 @@ verus! {
         /*** END: ADAPTED CODE BLOCK ***/
             assume (carry >> 52 < 2);
             assume (difference.limbs[i as int] < 1 << 52);
-            assume (addend < 1 << 52);
+            assume (L.limbs[i as int] < 1 << 52);
             carry = (carry >> 52) + difference.limbs[i] + addend;
             difference.limbs[i] = carry & mask;
         }

--- a/curve25519-dalek/src/backend/serial/u64/scalar_verus.rs
+++ b/curve25519-dalek/src/backend/serial/u64/scalar_verus.rs
@@ -425,7 +425,13 @@ verus! {
         for i in 0..5 
             invariant 0 <= i <= 5,
         {
-            assume(false);
+            proof {
+                assert (0 <= a.limbs[i as int].wrapping_sub(b.limbs[i as int]));
+                assume (2u64 << 52 >= a.limbs[i as int].wrapping_sub(b.limbs[i as int]));
+                assume ((borrow >> 63) <= 10);
+                assume (2u64 << 52 + 10 <= 2u64 << 53);
+                assume (2u64 << 53 >= a.limbs[i as int].wrapping_sub(b.limbs[i as int]) + (borrow >> 63) );
+            }
             borrow = a.limbs[i].wrapping_sub(b.limbs[i]) + (borrow >> 63);
             difference.limbs[i] = borrow & mask;
         }

--- a/curve25519-dalek/src/backend/serial/u64/scalar_verus.rs
+++ b/curve25519-dalek/src/backend/serial/u64/scalar_verus.rs
@@ -427,15 +427,6 @@ verus! {
             invariant 0 <= i <= 5,
         {
             proof {
-                calc! {
-                    (<=)
-                    a.limbs[i as int].wrapping_sub(b.limbs[i as int]) + (borrow >> 63); {assume (false);}
-                    (2u64 << 52) as int + (borrow >> 63); {assert (borrow >> 63 < 10) by (bit_vector);}
-                    (2u64 << 52) as int + 10;
-                }
-                assert (
-                    (2u64 << 52) as int + 10 <= (2u64 << 53) as int
-                ) by (compute_only);
                 assume (b.limbs[i as int] + (borrow >> 63) <= 2 << 53);
             }
             borrow = a.limbs[i].wrapping_sub(b.limbs[i] + (borrow >> 63));

--- a/curve25519-dalek/src/backend/serial/u64/scalar_verus.rs
+++ b/curve25519-dalek/src/backend/serial/u64/scalar_verus.rs
@@ -182,9 +182,22 @@ verus! {
                 assert((x as u128) * (1u128 << 52) < (1u128 << 52) * (1u128 << 52)) by
                   {lemma_mul_strict_inequality(x as int, (1u128 << 52) as int, (1u128 << 52) as int)};
                 assert((y as u128) < (1u128 << 52));
-                assume (x > 0);
-                assert((x as u128) * (y as u128) < (x as u128) * (1u128 << 52)) by
-                  {lemma_mul_strict_inequality(y as int, (1u128 << 52) as int, x as int)};
+                assert((x as u128) * (y as u128) <= (x as u128) * (1u128 << 52)) by
+                  {
+
+                      if x > 0
+                    {
+                      lemma_mul_strict_inequality(y as int, (1u128 << 52) as int, x as int)
+                    }
+                      else {
+                          assert (x == 0);
+                          assert ((x as u128) * (y as u128) == 0);
+                          assert ((x as u128) * (1u128 << 52) == 0);
+
+                      }
+
+
+                  };
                 assert((x as u128) * (y as u128) < (1u128 << 52) * (1u128 << 52));
                 assert((1u128 << 52) * (1u128 << 52) <= (1u128 << 104)) by (compute);
                 assert((x as u128) * (y as u128) < (1u128 << 104));

--- a/curve25519-dalek/src/backend/serial/u64/scalar_verus.rs
+++ b/curve25519-dalek/src/backend/serial/u64/scalar_verus.rs
@@ -407,8 +407,8 @@ verus! {
     /// Compute `a - b` (mod l)
     pub fn sub(a: &Scalar52, b: &Scalar52) -> (s: Scalar52)
     requires 
-        forall|i: int| 0 <= i < 5 ==> a.limbs[i] < (1u64 << 52),
-        forall|i: int| 0 <= i < 5 ==> b.limbs[i] < (1u64 << 52),
+        forall|j: int| 0 <= j < 5 ==> a.limbs[j] < (1u64 << 52),
+        forall|j: int| 0 <= j < 5 ==> b.limbs[j] < (1u64 << 52),
     ensures 
         to_nat(&s.limbs) == to_nat(&a.limbs) - to_nat(&b.limbs),
     {
@@ -425,9 +425,12 @@ verus! {
         let mut borrow: u64 = 0;
         for i in 0..5 
             invariant 0 <= i <= 5,
+                      forall|j: int| 0 <= j < 5 ==> b.limbs[j] < (1u64 << 52),
         {
             proof {
-                assume (b.limbs[i as int] + (borrow >> 63) <= 2 << 53);
+                assert (b.limbs[i as int] < (1u64 << 52));
+                assert ((borrow >> 63) < 2) by (bit_vector);
+                assert (b.limbs[i as int] + (borrow >> 63) <= (1u64 << 52) + 2);
             }
             borrow = a.limbs[i].wrapping_sub(b.limbs[i] + (borrow >> 63));
             difference.limbs[i] = borrow & mask;

--- a/curve25519-dalek/src/backend/serial/u64/scalar_verus.rs
+++ b/curve25519-dalek/src/backend/serial/u64/scalar_verus.rs
@@ -436,6 +436,7 @@ verus! {
                 assert (
                     (2u64 << 52) as int + 10 <= (2u64 << 53) as int
                 ) by (compute_only);
+                assume (b.limbs[i as int] + (borrow >> 63) <= 2 << 53);
             }
             borrow = a.limbs[i].wrapping_sub(b.limbs[i] + (borrow >> 63));
             difference.limbs[i] = borrow & mask;

--- a/curve25519-dalek/src/backend/serial/u64/scalar_verus.rs
+++ b/curve25519-dalek/src/backend/serial/u64/scalar_verus.rs
@@ -428,9 +428,7 @@ verus! {
                       forall|j: int| 0 <= j < 5 ==> b.limbs[j] < (1u64 << 52),
         {
             proof {
-                assert (b.limbs[i as int] < (1u64 << 52));
                 assert ((borrow >> 63) < 2) by (bit_vector);
-                assert (b.limbs[i as int] + (borrow >> 63) <= (1u64 << 52) + 2);
             }
             borrow = a.limbs[i].wrapping_sub(b.limbs[i] + (borrow >> 63));
             difference.limbs[i] = borrow & mask;

--- a/curve25519-dalek/src/backend/serial/u64/scalar_verus.rs
+++ b/curve25519-dalek/src/backend/serial/u64/scalar_verus.rs
@@ -187,18 +187,6 @@ verus! {
             (1u64 << 252) as nat + 27742317777372353535851937790883648493nat
         }
 
-        /// Custom wrapping subtraction: a - b, wrapping on underflow
-        fn wrapping_sub_verus(a: u64, b: u64) -> (result: u64)
-        ensures 
-            result == if a >= b { a - b } else { u64::MAX - (b - a) + 1 },
-        {
-            if a >= b {
-                a - b
-            } else {
-                u64::MAX - (b - a) + 1
-            }
-        }
-
         // TODO vstd defines wrapping sub using a conditional subtraction,
         // which is maybe easier to reason about
         pub assume_specification[u64::wrapping_mul](x: u64, y: u64) -> u64
@@ -438,7 +426,7 @@ verus! {
             invariant 0 <= i <= 5,
         {
             assume(false);
-            borrow = wrapping_sub_verus(a.limbs[i], b.limbs[i] + (borrow >> 63));
+            borrow = a.limbs[i].wrapping_sub(b.limbs[i]) + (borrow >> 63);
             difference.limbs[i] = borrow & mask;
         }
 

--- a/curve25519-dalek/src/backend/serial/u64/scalar_verus.rs
+++ b/curve25519-dalek/src/backend/serial/u64/scalar_verus.rs
@@ -8,6 +8,7 @@ use vstd::arithmetic::power2::*;
 
 verus! {
 
+
         /****** INLINE SUBTLE_VERUS FUNCTIONALITY ******/
         
         /// A type representing a choice between two values.
@@ -198,14 +199,10 @@ verus! {
             }
         }
 
-        /// Custom wrapping multiplication: a * b, wrapping on overflow
-        fn wrapping_mul_verus(a: u64, b: u64) -> (result: u64)
-        ensures
-            result == ((a as nat * b as nat) % ((1u64 << 64) as nat)) as u64,
-        {
-            assume(false);
-            ((a as u128) * (b as u128)) as u64
-        }
+        // TODO vstd defines wrapping sub using a conditional subtraction,
+        // which is maybe easier to reason about
+        pub assume_specification[u64::wrapping_mul](x: u64, y: u64) -> u64
+            returns ((x as nat * y as nat) % ((1u64 << 64) as nat)) as u64;
 
         /// u64 * u64 = u128 multiply helper
         #[inline(always)]
@@ -576,8 +573,7 @@ verus! {
     fn montgomery_part1(sum: u128) -> (u128, u64)
     {
         assume(false); // TODO: Add proper bounds checking and proofs
-        // Use our Verus-compatible wrapping multiplication
-        let p = wrapping_mul_verus(sum as u64, LFACTOR) & ((1u64 << 52) - 1);
+        let p = (sum as u64).wrapping_mul(LFACTOR) & ((1u64 << 52) - 1);
         let carry = (sum + m(p, L.limbs[0])) >> 52;
         (carry, p)
     }

--- a/curve25519-dalek/src/backend/serial/u64/scalar_verus.rs
+++ b/curve25519-dalek/src/backend/serial/u64/scalar_verus.rs
@@ -175,12 +175,11 @@ verus! {
             proof {
                 assert(1u128 << 52 == 1u64 << 52) by (bit_vector);
                 assert((x as u128) < (1u128 << 52));
+                assert((y as u128) < (1u128 << 52));
                 assert((x as u128) * (1u128 << 52) < (1u128 << 52) * (1u128 << 52)) by
                   {lemma_mul_strict_inequality(x as int, (1u128 << 52) as int, (1u128 << 52) as int)};
-                assert((y as u128) < (1u128 << 52));
                 assert((x as u128) * (y as u128) <= (x as u128) * (1u128 << 52)) by
                   {
-
                     if x > 0
                     {
                       lemma_mul_strict_inequality(y as int, (1u128 << 52) as int, x as int)
@@ -191,8 +190,7 @@ verus! {
                     }
                   };
                 assert((x as u128) * (y as u128) < (1u128 << 52) * (1u128 << 52));
-                assert((1u128 << 52) * (1u128 << 52) <= (1u128 << 104)) by (compute);
-                assert((x as u128) * (y as u128) < (1u128 << 104));
+                assert((1u128 << 52) * (1u128 << 52) == (1u128 << 104)) by (compute);
             }
             (x as u128) * (y as u128)
         }

--- a/curve25519-dalek/src/backend/serial/u64/scalar_verus.rs
+++ b/curve25519-dalek/src/backend/serial/u64/scalar_verus.rs
@@ -209,7 +209,6 @@ verus! {
 
         /// Unpack a 32 byte / 256 bit scalar into 5 52-bit limbs.
         #[rustfmt::skip] // keep alignment of s[*] calculations
-
         /* ADAPTED CODE LINE: we give a name to the output: "s" */
         pub fn from_bytes(bytes: &[u8; 32]) -> (s: Scalar52) 
         // SPECIFICATION: unpacking keeps the same nat value
@@ -268,6 +267,7 @@ verus! {
     /// Pack the limbs of this `Scalar52` into 32 bytes
     #[rustfmt::skip] // keep alignment of s[*] calculations
     #[allow(clippy::identity_op)]
+    #[allow(clippy::wrong_self_convention)]
     pub fn to_bytes(self) -> (s: [u8; 32]) 
     // DIFF-SPEC-3: we give a name to the output: "s"
     // SPECIFICATION: packing keeps the same nat value
@@ -375,11 +375,10 @@ verus! {
         assert(to_nat(&l_value.limbs) == to_nat(&L.limbs));
         assume(false); // TODO: complete the proof
 
-        let mut s = Scalar52::sub(&sum, &l_value);
+        Scalar52::sub(&sum, &l_value)
         
         /*** END: ADAPTED CODE BLOCK ***/
 
-        s
     }
 
     /// Compute `a - b` (mod l)

--- a/curve25519-dalek/src/backend/serial/u64/scalar_verus.rs
+++ b/curve25519-dalek/src/backend/serial/u64/scalar_verus.rs
@@ -1,7 +1,7 @@
 // scalar64_verus.rs
 #![allow(unused)]
 use vstd::prelude::*;
-use vstd::arithmetic::mul::lemma_mul_strict_inequality;
+use vstd::arithmetic::mul::*;
 use vstd::calc;
 use vstd::arithmetic::power2::*;
 use subtle::{Choice, ConditionallySelectable};

--- a/curve25519-dalek/src/backend/serial/u64/scalar_verus.rs
+++ b/curve25519-dalek/src/backend/serial/u64/scalar_verus.rs
@@ -176,10 +176,9 @@ verus! {
                 assert(1u128 << 52 == 1u64 << 52) by (bit_vector);
                 assert((x as u128) < (1u128 << 52));
                 assert((y as u128) < (1u128 << 52));
-                // Start here AI
                 calc! {
-                    (<=)
-                    (x as u128) * (y as u128); {
+                    (<)
+                    (x as u128) * (y as u128); (<=) {
                         if x > 0 {
                             lemma_mul_strict_inequality(y as int, (1u128 << 52) as int, x as int);
                         } else {
@@ -188,15 +187,14 @@ verus! {
                             assert((x as u128) * (1u128 << 52) == 0);
                         }
                     }
-                    (x as u128) * (1u128 << 52); {
+                    (x as u128) * (1u128 << 52); (<) {
                         lemma_mul_strict_inequality(x as int, (1u128 << 52) as int, (1u128 << 52) as int);
                     }
-                    (1u128 << 52) * (1u128 << 52); {
+                    (1u128 << 52) * (1u128 << 52); (==) {
                         assert((1u128 << 52) * (1u128 << 52) == (1u128 << 104)) by (compute);
                     }
-                    (1u128 << 104);
+                    (1u128 << 104) as int;
                 }
-                // Finish here AI
             }
             (x as u128) * (y as u128)
         }

--- a/curve25519-dalek/src/backend/serial/u64/scalar_verus.rs
+++ b/curve25519-dalek/src/backend/serial/u64/scalar_verus.rs
@@ -165,18 +165,18 @@ verus! {
         /// u64 * u64 = u128 multiply helper
         #[inline(always)]
         fn m(x: u64, y: u64) -> (z: u128)
-        requires 
+        requires
             x < (1u64 << 52),
             y < (1u64 << 52),
-        ensures 
+        ensures
             z < (1u128 << 104),
             z == x * y
         {
             proof {
                 assert(x < (1u64 << 52));
                 assert(y < (1u64 << 52));
-                assert((x as u128) == x as u64); 
-                assert((y as u128) == y as u64); 
+                assert((x as u128) == x as u64);
+                assert((y as u128) == y as u64);
                 assert(1u128 << 52 == 1u64 << 52) by (bit_vector);
                 assert((x as u128) < (1u128 << 52));
                 assert((x as u128) * (1u128 << 52) < (1u128 << 52) * (1u128 << 52)) by
@@ -185,18 +185,14 @@ verus! {
                 assert((x as u128) * (y as u128) <= (x as u128) * (1u128 << 52)) by
                   {
 
-                      if x > 0
+                    if x > 0
                     {
                       lemma_mul_strict_inequality(y as int, (1u128 << 52) as int, x as int)
+                    } else {
+                        assert (x == 0);
+                        assert ((x as u128) * (y as u128) == 0);
+                        assert ((x as u128) * (1u128 << 52) == 0);
                     }
-                      else {
-                          assert (x == 0);
-                          assert ((x as u128) * (y as u128) == 0);
-                          assert ((x as u128) * (1u128 << 52) == 0);
-
-                      }
-
-
                   };
                 assert((x as u128) * (y as u128) < (1u128 << 52) * (1u128 << 52));
                 assert((1u128 << 52) * (1u128 << 52) <= (1u128 << 104)) by (compute);

--- a/curve25519-dalek/src/backend/serial/u64/scalar_verus.rs
+++ b/curve25519-dalek/src/backend/serial/u64/scalar_verus.rs
@@ -183,8 +183,7 @@ verus! {
                 assume((1u128 << 52) * (1u128 << 52) < (1u128 << 104)); // by (nonlinear_arith);
                 assert((x as u128) * (y as u128) < (1u128 << 104));
             }
-            let z = (x as u128) * (y as u128);
-            z
+            (x as u128) * (y as u128)
         }
 
         pub struct Scalar52 {

--- a/curve25519-dalek/src/backend/serial/u64/scalar_verus.rs
+++ b/curve25519-dalek/src/backend/serial/u64/scalar_verus.rs
@@ -177,20 +177,25 @@ verus! {
                 assert((x as u128) < (1u128 << 52));
                 assert((y as u128) < (1u128 << 52));
                 // Start here AI
-                assert((x as u128) * (y as u128) <= (x as u128) * (1u128 << 52)) by
-                  {
-                    if x > 0
-                    {
-                      lemma_mul_strict_inequality(y as int, (1u128 << 52) as int, x as int)
-                    } else {
-                        assert (x == 0);
-                        assert ((x as u128) * (y as u128) == 0);
-                        assert ((x as u128) * (1u128 << 52) == 0);
+                calc! {
+                    (<=)
+                    (x as u128) * (y as u128); {
+                        if x > 0 {
+                            lemma_mul_strict_inequality(y as int, (1u128 << 52) as int, x as int);
+                        } else {
+                            assert(x == 0);
+                            assert((x as u128) * (y as u128) == 0);
+                            assert((x as u128) * (1u128 << 52) == 0);
+                        }
                     }
-                  };
-                assert((x as u128) * (1u128 << 52) < (1u128 << 52) * (1u128 << 52)) by
-                  {lemma_mul_strict_inequality(x as int, (1u128 << 52) as int, (1u128 << 52) as int)};
-                assert((1u128 << 52) * (1u128 << 52) == (1u128 << 104)) by (compute);
+                    (x as u128) * (1u128 << 52); {
+                        lemma_mul_strict_inequality(x as int, (1u128 << 52) as int, (1u128 << 52) as int);
+                    }
+                    (1u128 << 52) * (1u128 << 52); {
+                        assert((1u128 << 52) * (1u128 << 52) == (1u128 << 104)) by (compute);
+                    }
+                    (1u128 << 104);
+                }
                 // Finish here AI
             }
             (x as u128) * (y as u128)

--- a/curve25519-dalek/src/backend/serial/u64/scalar_verus.rs
+++ b/curve25519-dalek/src/backend/serial/u64/scalar_verus.rs
@@ -384,8 +384,8 @@ verus! {
     /// Compute `a - b` (mod l)
     pub fn sub(a: &Scalar52, b: &Scalar52) -> (s: Scalar52)
     requires 
-        forall|j: int| 0 <= j < 5 ==> a.limbs[j] < (1u64 << 52),
-        forall|j: int| 0 <= j < 5 ==> b.limbs[j] < (1u64 << 52),
+        forall|i: int| 0 <= i < 5 ==> a.limbs[i] < (1u64 << 52),
+        forall|i: int| 0 <= i < 5 ==> b.limbs[i] < (1u64 << 52),
     ensures 
         to_nat(&s.limbs) == to_nat(&a.limbs) - to_nat(&b.limbs),
     {

--- a/curve25519-dalek/src/backend/serial/u64/scalar_verus.rs
+++ b/curve25519-dalek/src/backend/serial/u64/scalar_verus.rs
@@ -412,7 +412,9 @@ verus! {
         // OUR ADAPTED CODE FOR VERUS
             let addend = select(&0, &L.limbs[i], underflow);
         /*** END: ADAPTED CODE BLOCK ***/
-            assume(false);
+            assume (carry >> 52 < 2);
+            assume (difference.limbs[i as int] < 1 << 52);
+            assume (addend < 1 << 52);
             carry = (carry >> 52) + difference.limbs[i] + addend;
             difference.limbs[i] = carry & mask;
         }

--- a/curve25519-dalek/src/backend/serial/u64/scalar_verus.rs
+++ b/curve25519-dalek/src/backend/serial/u64/scalar_verus.rs
@@ -1,6 +1,7 @@
 // scalar64_verus.rs
 #![allow(unused)]
 use vstd::prelude::*;
+use vstd::arithmetic::mul::lemma_mul_by_zero_is_zero;
 use vstd::arithmetic::mul::lemma_mul_strict_inequality;
 use vstd::calc;
 use vstd::arithmetic::power2::*;
@@ -173,15 +174,10 @@ verus! {
             z == x * y
         {
             proof {
-                assert(x < (1u64 << 52));
-                assert(y < (1u64 << 52));
-                assert((x as u128) == x as u64);
-                assert((y as u128) == y as u64);
                 assert(1u128 << 52 == 1u64 << 52) by (bit_vector);
                 assert((x as u128) < (1u128 << 52));
                 assert((x as u128) * (1u128 << 52) < (1u128 << 52) * (1u128 << 52)) by
                   {lemma_mul_strict_inequality(x as int, (1u128 << 52) as int, (1u128 << 52) as int)};
-                assert((y as u128) < (1u128 << 52));
                 assert((x as u128) * (y as u128) <= (x as u128) * (1u128 << 52)) by
                   {
 
@@ -190,8 +186,8 @@ verus! {
                       lemma_mul_strict_inequality(y as int, (1u128 << 52) as int, x as int)
                     } else {
                         assert (x == 0);
-                        assert ((x as u128) * (y as u128) == 0);
-                        assert ((x as u128) * (1u128 << 52) == 0);
+                        assert ((x as u128) * (y as u128) == 0) by {lemma_mul_by_zero_is_zero(x as int)};
+                        assert ((x as u128) * (1u128 << 52) == 0) by {lemma_mul_by_zero_is_zero(x as int)};
                     }
                   };
                 assert((x as u128) * (y as u128) < (1u128 << 52) * (1u128 << 52));

--- a/curve25519-dalek/src/backend/serial/u64/scalar_verus.rs
+++ b/curve25519-dalek/src/backend/serial/u64/scalar_verus.rs
@@ -176,8 +176,6 @@ verus! {
                 assert(1u128 << 52 == 1u64 << 52) by (bit_vector);
                 assert((x as u128) < (1u128 << 52));
                 assert((y as u128) < (1u128 << 52));
-                assert((x as u128) * (1u128 << 52) < (1u128 << 52) * (1u128 << 52)) by
-                  {lemma_mul_strict_inequality(x as int, (1u128 << 52) as int, (1u128 << 52) as int)};
                 assert((x as u128) * (y as u128) <= (x as u128) * (1u128 << 52)) by
                   {
                     if x > 0
@@ -189,6 +187,8 @@ verus! {
                         assert ((x as u128) * (1u128 << 52) == 0);
                     }
                   };
+                assert((x as u128) * (1u128 << 52) < (1u128 << 52) * (1u128 << 52)) by
+                  {lemma_mul_strict_inequality(x as int, (1u128 << 52) as int, (1u128 << 52) as int)};
                 assert((1u128 << 52) * (1u128 << 52) == (1u128 << 104)) by (compute);
             }
             (x as u128) * (y as u128)

--- a/curve25519-dalek/src/backend/serial/u64/scalar_verus.rs
+++ b/curve25519-dalek/src/backend/serial/u64/scalar_verus.rs
@@ -437,7 +437,7 @@ verus! {
                     (2u64 << 52) as int + 10 <= (2u64 << 53) as int
                 ) by (compute_only);
             }
-            borrow = a.limbs[i].wrapping_sub(b.limbs[i]) + (borrow >> 63);
+            borrow = a.limbs[i].wrapping_sub(b.limbs[i] + borrow >> 63);
             difference.limbs[i] = borrow & mask;
         }
 

--- a/curve25519-dalek/src/lib.rs
+++ b/curve25519-dalek/src/lib.rs
@@ -28,7 +28,6 @@
     missing_docs,
     rust_2018_idioms,
     unused_lifetimes,
-    unused_qualifications
 )]
 
 //------------------------------------------------------------------------


### PR DESCRIPTION
This function verifies without assumes:
```rust
        fn m(x: u64, y: u64) -> (z: u128)
        requires
            x < (1u64 << 52),
            y < (1u64 << 52),
        ensures
            z < (1u128 << 104),
            z == x * y
```
I've also made a little progress on removing assumes in `sub`, but I haven't started the difficult part of understanding the algorithm to find the right invariants