### PR TITLE
Verus-enhanced `field.rs`

### DIFF
--- a/curve25519-dalek/src/backend/serial/u64/field_verus.rs
+++ b/curve25519-dalek/src/backend/serial/u64/field_verus.rs
@@ -1,0 +1,549 @@
+// field.rs
+#![allow(unused)]
+use vstd::arithmetic::div_mod::*;
+use vstd::arithmetic::mul::*;
+use vstd::arithmetic::power2::*;
+use vstd::bits::*;
+use vstd::prelude::*;
+
+// ADAPTED CODE LINES: X.0 globally replaced with X.limbs
+
+verus! {
+
+
+/* MANUALLY moved outside and made explicit */
+// LOW_51_BIT_MASK: u64 = (1u64 << 51) -1; originally
+pub const LOW_51_BIT_MASK: u64 = 2251799813685247u64; // 2^51  -1
+
+// Basic properties of LOW_51_BIT_MASK:
+// - It's the value of low_bits_mask (spec function defined in vstd and used in its lemmas)
+// - it's less than 2^51
+pub proof fn l51_bit_mask_lt()
+    ensures
+        LOW_51_BIT_MASK == low_bits_mask(51),
+        LOW_51_BIT_MASK < (1u64 << 51) as nat,
+{
+    lemma2_to64_rest();
+    lemma_pow2_pos(51);
+    assert(LOW_51_BIT_MASK < (1u64 << 51) as nat) by (compute);
+    assert(LOW_51_BIT_MASK == low_bits_mask(51)) by (compute);
+}
+
+// Auxiliary lemma for multiplication (of nat!)
+pub proof fn mul_lt(a1:nat, b1:nat, a2:nat, b2:nat)
+    requires
+        a1 < b1,
+        a2 < b2,
+    ensures
+        a1 * a2 < b1 * b2,
+{
+    assert(b1 > 0);
+    if (a2 == 0) {
+        assert(a1 * a2 == 0);
+        assert(b1 * b2 > 0) by {
+            // a * b != 0 <==> a != 0 /\ b != 0
+            lemma_mul_nonzero(b1 as int, b2 as int);
+        }
+    }
+    else {
+        assert(a2 > 0);
+        // a1 < b1 /\ a2 > 0 ==> a1 * a2 < b1 * a2
+        lemma_mul_strict_inequality(a1 as int, b1  as int, a2 as int);
+        // a2 < b2 /\ b2 > 0 ==> a2 * b1 < b2 * b1
+        lemma_mul_strict_inequality(a2 as int, b2 as int, b1 as int);
+    }
+}
+
+// Auxiliary lemma for exponentiation
+pub proof fn pow2_le_max64(k: nat)
+    requires
+        k < 64,
+    ensures
+        pow2(k) <= u64::MAX
+    {
+        lemma2_to64();
+        lemma2_to64_rest();
+    }
+
+// Specialization of lemma_u64_shl_is_mul for x = 1
+pub proof fn shift_is_pow2(k: nat)
+    requires
+        k < 64,
+    ensures
+        (1u64 << k) == pow2(k)
+{
+    pow2_le_max64(k);
+    lemma_u64_shl_is_mul(1u64, k as u64);
+    assert((1u64 << k) == 1u64 * pow2(k));
+    assert(1u64 * pow2(k) == pow2(k));
+}
+
+// Masking with low_bits_mask(k) gives a value bounded by 2^k
+pub proof fn masked_lt(v: u64)
+    ensures
+        v & LOW_51_BIT_MASK < (1u64 << 51),
+{
+    l51_bit_mask_lt();
+    assert(LOW_51_BIT_MASK == low_bits_mask(51) as u64);
+    assert(v & LOW_51_BIT_MASK == v & (low_bits_mask(51) as u64));
+    lemma_u64_low_bits_mask_is_mod(v, 51);
+    assert(v & (low_bits_mask(51) as u64) == v % (pow2(51) as u64));
+    lemma_pow2_pos(51);
+    lemma_mod_division_less_than_divisor(v as int, pow2(51) as int);
+    assert(v & (low_bits_mask(51) as u64) < pow2(51));
+    shift_is_pow2(51);
+}
+
+// right-shifting a u64 gives at most 2^13 - 1
+pub proof fn shifted_lt(v: u64)
+    ensures
+        v >> 51 < 1u64 << 13
+{
+    shift_is_pow2(13);
+    assert(v <= u64::MAX);
+    lemma_u64_shr_is_div(u64::MAX, 51);
+    lemma_u64_shr_is_div(v, 51);
+    lemma_pow2_pos(51);
+    lemma_div_is_ordered(v as int, u64::MAX as int, pow2(51) as int);
+    assert(v >> 51 <= u64::MAX >> 51);
+    assert(u64::MAX >> 51 < 1u64 << 13) by (compute);
+}
+
+
+/* MANUALLY moved outside, named return value */
+const fn load8_at(input: &[u8], i: usize) -> (r: u64)
+    requires
+        i + 7 < input.len(),
+    ensures
+        0 <= r <= (u64::MAX as nat),
+{
+        (input[i] as u64)
+    | ((input[i + 1] as u64) << 8)
+    | ((input[i + 2] as u64) << 16)
+    | ((input[i + 3] as u64) << 24)
+    | ((input[i + 4] as u64) << 32)
+    | ((input[i + 5] as u64) << 40)
+    | ((input[i + 6] as u64) << 48)
+    | ((input[i + 7] as u64) << 56)
+}
+
+/* MANUALLY moved outside */
+#[inline(always)]
+fn m(x: u64, y: u64) -> (r: u128)
+    requires
+        (x as nat) * (y as nat) < (u128::MAX as nat),
+    ensures
+        (r as nat) == (x as nat) * (y as nat),
+{
+    (x as u128) * (y as u128)
+}
+
+pub struct FieldElement51 {
+    // ADAPTED CODE LINE: we give a name to the field: "limbs"
+    pub limbs: [u64; 5],
+}
+
+impl FieldElement51 {
+    pub(crate) const fn from_limbs(limbs: [u64; 5]) -> FieldElement51 {
+        // ADAPTED CODE LINE: limbs is now a named field
+        FieldElement51{limbs: limbs}
+    }
+
+    // Modified to use direct struct
+    pub const ZERO: FieldElement51 = FieldElement51{limbs: [0, 0, 0, 0, 0]};
+    pub const ONE: FieldElement51 = FieldElement51{limbs: [1, 0, 0, 0, 0]};
+    pub const MINUS_ONE: FieldElement51 = FieldElement51{limbs: [
+        2251799813685228,
+        2251799813685247,
+        2251799813685247,
+        2251799813685247,
+        2251799813685247,
+    ]};
+
+    /// Invert the sign of this field element
+    pub fn negate(&mut self)
+        requires
+            forall|i: int| 0 <= i < 5 ==> old(self).limbs[i] < (1u64 << 52),
+        ensures
+            forall|i: int| 0 <= i < 5 ==> self.limbs[i] < (1u64 << 52),
+            forall|i: int| 0 <= i < 5 ==> self.limbs[i] + old(self).limbs[i] % (pow2(52) as u64) == 0,
+    {
+        proof {
+            // lemma2_to64_rest(); // get pow2(51)
+            // assert(36028797018963664u64 == 16 * (pow2(51) - 19)) by (compute);
+            // assert(36028797018963952u64 == 16 * (pow2(51) - 1)) by (compute);
+            assume(false);
+        }
+        // See commentary in the Sub impl: (copied below)
+            // To avoid underflow, first add a multiple of p.
+            // Choose 16*p = p << 4 to be larger than 54-bit _rhs.
+            //
+            // If we could statically track the bitlengths of the limbs
+            // of every FieldElement51, we could choose a multiple of p
+            // just bigger than _rhs and avoid having to do a reduction.
+            //
+            // Since we don't yet have type-level integers to do this, we
+            // have to add an explicit reduction call here.
+        // Note on "magic numbers":
+        // 36028797018963664u64 = 2^55 - 304 = 16 * (2^51 - 19)
+        // 36028797018963952u64 = 2^55 - 16 =  16 * (2^51 - 1)
+        let neg = FieldElement51::reduce([
+            36028797018963664u64 - self.limbs[0],
+            36028797018963952u64 - self.limbs[1],
+            36028797018963952u64 - self.limbs[2],
+            36028797018963952u64 - self.limbs[3],
+            36028797018963952u64 - self.limbs[4],
+        ]);
+        self.limbs = neg.limbs;
+    }
+
+    /// Given 64-bit input limbs, reduce to enforce the bound 2^(51 + epsilon).
+    #[inline(always)]
+    fn reduce(mut limbs: [u64; 5]) -> (r: FieldElement51)
+        ensures
+            forall|i: int| 0 <= i < 5 ==> r.limbs[i] < (1u64 << 52)
+    {
+        proof {
+            // \A i. limbs[i] < 2^13
+            shifted_lt(limbs[0]);
+            shifted_lt(limbs[1]);
+            shifted_lt(limbs[2]);
+            shifted_lt(limbs[3]);
+            shifted_lt(limbs[4]);
+
+            // \A i. limbs[i] & LOW_51_BIT_MASK < 2^51
+            masked_lt(limbs[0]);
+            masked_lt(limbs[1]);
+            masked_lt(limbs[2]);
+            masked_lt(limbs[3]);
+            masked_lt(limbs[4]);
+
+            // Since 19 < 2^5 and (limbs[4] >> 51) < 2^13, their product is less than 2^18
+            assert((limbs[4] >> 51) * 19 < (1u64 << 18) as nat) by {
+                assert(19 < (1u64 << 5)) by (bit_vector);
+                shift_is_pow2(5);
+                shift_is_pow2(13);
+                shift_is_pow2(18);
+                lemma_pow2_adds(13, 5);
+                assert((1u64 << 5) == pow2(5));
+                assert((1u64 << 13) == pow2(13));
+                assert((1u64 << 13) * (1u64 << 5) == pow2(13) * pow2(5));
+                assert(pow2(13) * pow2(5) == pow2(18));
+                assert((1u64 << 18) == pow2(18));
+                assert((1u64 << 13) * (1u64 << 5) == (1u64 << 18));
+                mul_lt((limbs[4] >> 51) as nat, (1u64 << 13) as nat, 19nat, (1u64 << 5) as nat);
+            }
+
+            // The final values (limbs[i] += cX) are all bounded by 2^51 + eps, for eps \in {2^18, 2^13}.
+            assert(((limbs[4] >> 51) * 19) + (limbs[0] & LOW_51_BIT_MASK) < ((1u64 << 18)) + (1u64 << 51) );
+            assert((limbs[0] >> 51) + (limbs[1] & LOW_51_BIT_MASK) < ((1u64 << 13)) + (1u64 << 51) );
+            assert((limbs[1] >> 51) + (limbs[2] & LOW_51_BIT_MASK) < ((1u64 << 13)) + (1u64 << 51) );
+            assert((limbs[2] >> 51) + (limbs[3] & LOW_51_BIT_MASK) < ((1u64 << 13)) + (1u64 << 51) );
+            assert((limbs[3] >> 51) + (limbs[4] & LOW_51_BIT_MASK) < ((1u64 << 13)) + (1u64 << 51) );
+
+            assert(((1u64 << 18)) + (1u64 << 51) < (1u64 << 52)) by {
+                shift_is_pow2(18);
+                shift_is_pow2(51);
+                shift_is_pow2(52);
+                lemma_pow2_strictly_increases(18, 51);
+                lemma_pow2_unfold(52);
+            }
+
+            assert(((1u64 << 13)) + (1u64 << 51) < (1u64 << 52)) by {
+                shift_is_pow2(13);
+                shift_is_pow2(51);
+                shift_is_pow2(52);
+                lemma_pow2_strictly_increases(13, 51);
+                lemma_pow2_unfold(52);
+            }
+
+            // In summary, they're all bounded by 2^52
+            assert(((limbs[4] >> 51) * 19) + (limbs[0] & LOW_51_BIT_MASK) < (1u64 << 52));
+            assert((limbs[0] >> 51) + (limbs[1] & LOW_51_BIT_MASK) < (1u64 << 52));
+            assert((limbs[1] >> 51) + (limbs[2] & LOW_51_BIT_MASK) < (1u64 << 52));
+            assert((limbs[2] >> 51) + (limbs[3] & LOW_51_BIT_MASK) < (1u64 << 52));
+            assert((limbs[3] >> 51) + (limbs[4] & LOW_51_BIT_MASK) < (1u64 << 52));
+        }
+
+        // Since the input limbs are bounded by 2^64, the biggest
+        // carry-out is bounded by 2^13.
+        //
+        // The biggest carry-in is c4 * 19, resulting in
+        //
+        // 2^51 + 19*2^13 < 2^51.0000000001
+        //
+        // Because we don't need to canonicalize, only to reduce the
+        // limb sizes, it's OK to do a "weak reduction", where we
+        // compute the carry-outs in parallel.
+
+        let c0 = limbs[0] >> 51;
+        let c1 = limbs[1] >> 51;
+        let c2 = limbs[2] >> 51;
+        let c3 = limbs[3] >> 51;
+        let c4 = limbs[4] >> 51;
+
+        limbs[0] &= LOW_51_BIT_MASK;
+        limbs[1] &= LOW_51_BIT_MASK;
+        limbs[2] &= LOW_51_BIT_MASK;
+        limbs[3] &= LOW_51_BIT_MASK;
+        limbs[4] &= LOW_51_BIT_MASK;
+
+        limbs[0] += c4 * 19;
+        limbs[1] += c0;
+        limbs[2] += c1;
+        limbs[3] += c2;
+        limbs[4] += c3;
+
+        // ADAPTED CODE LINE: limbs is now a named field
+        FieldElement51{limbs: limbs}
+    }
+
+    /// Load a `FieldElement51` from the low 255 bits of a 256-bit
+    /// input.
+    ///
+    /// # Warning
+    ///
+    /// This function does not check that the input used the canonical
+    /// representative.  It masks the high bit, but it will happily
+    /// decode 2^255 - 18 to 1.  Applications that require a canonical
+    /// encoding of every field element should decode, re-encode to
+    /// the canonical encoding, and check that the input was
+    /// canonical.
+    ///
+    #[rustfmt::skip] // keep alignment of bit shifts
+    pub const fn from_bytes(bytes: &[u8; 32]) -> FieldElement51 {
+        let low_51_bit_mask = (1u64 << 51) - 1;
+        // ADAPTED CODE LINE: limbs is now a named field
+        FieldElement51{ limbs:
+        // load bits [  0, 64), no shift
+        [  load8_at(bytes,  0)        & low_51_bit_mask
+        // load bits [ 48,112), shift to [ 51,112)
+        , (load8_at(bytes,  6) >>  3) & low_51_bit_mask
+        // load bits [ 96,160), shift to [102,160)
+        , (load8_at(bytes, 12) >>  6) & low_51_bit_mask
+        // load bits [152,216), shift to [153,216)
+        , (load8_at(bytes, 19) >>  1) & low_51_bit_mask
+        // load bits [192,256), shift to [204,112)
+        , (load8_at(bytes, 24) >> 12) & low_51_bit_mask
+        ]}
+    }
+
+    /// Serialize this `FieldElement51` to a 32-byte array.  The
+    /// encoding is canonical.
+    #[rustfmt::skip] // keep alignment of s[*] calculations
+    pub fn to_bytes(self) -> [u8; 32] {
+        // Let h = limbs[0] + limbs[1]*2^51 + ... + limbs[4]*2^204.
+        //
+        // Write h = pq + r with 0 <= r < p.
+        //
+        // We want to compute r = h mod p.
+        //
+        // If h < 2*p = 2^256 - 38,
+        // then q = 0 or 1,
+        //
+        // with q = 0 when h < p
+        //  and q = 1 when h >= p.
+        //
+        // Notice that h >= p <==> h + 19 >= p + 19 <==> h + 19 >= 2^255.
+        // Therefore q can be computed as the carry bit of h + 19.
+
+        // First, reduce the limbs to ensure h < 2*p.
+        let mut limbs = FieldElement51::reduce(self.limbs).limbs;
+
+        let mut q = (limbs[0] + 19) >> 51;
+        q = (limbs[1] + q) >> 51;
+        q = (limbs[2] + q) >> 51;
+        q = (limbs[3] + q) >> 51;
+        q = (limbs[4] + q) >> 51;
+
+        // Now we can compute r as r = h - pq = r - (2^255-19)q = r + 19q - 2^255q
+
+        limbs[0] += 19 * q;
+
+        // Now carry the result to compute r + 19q ...
+        let low_51_bit_mask = (1u64 << 51) - 1;
+        limbs[1] += limbs[0] >> 51;
+        limbs[0] &= low_51_bit_mask;
+        limbs[2] += limbs[1] >> 51;
+        limbs[1] &= low_51_bit_mask;
+        limbs[3] += limbs[2] >> 51;
+        limbs[2] &= low_51_bit_mask;
+        limbs[4] += limbs[3] >> 51;
+        limbs[3] &= low_51_bit_mask;
+        // ... but instead of carrying (limbs[4] >> 51) = 2^255q
+        // into another limb, discard it, subtracting the value
+        limbs[4] &= low_51_bit_mask;
+
+        // Now arrange the bits of the limbs.
+        let mut s = [0u8;32];
+        s[ 0] =   limbs[0]                           as u8;
+        s[ 1] =  (limbs[0] >>  8)                    as u8;
+        s[ 2] =  (limbs[0] >> 16)                    as u8;
+        s[ 3] =  (limbs[0] >> 24)                    as u8;
+        s[ 4] =  (limbs[0] >> 32)                    as u8;
+        s[ 5] =  (limbs[0] >> 40)                    as u8;
+        s[ 6] = ((limbs[0] >> 48) | (limbs[1] << 3)) as u8;
+        s[ 7] =  (limbs[1] >>  5)                    as u8;
+        s[ 8] =  (limbs[1] >> 13)                    as u8;
+        s[ 9] =  (limbs[1] >> 21)                    as u8;
+        s[10] =  (limbs[1] >> 29)                    as u8;
+        s[11] =  (limbs[1] >> 37)                    as u8;
+        s[12] = ((limbs[1] >> 45) | (limbs[2] << 6)) as u8;
+        s[13] =  (limbs[2] >>  2)                    as u8;
+        s[14] =  (limbs[2] >> 10)                    as u8;
+        s[15] =  (limbs[2] >> 18)                    as u8;
+        s[16] =  (limbs[2] >> 26)                    as u8;
+        s[17] =  (limbs[2] >> 34)                    as u8;
+        s[18] =  (limbs[2] >> 42)                    as u8;
+        s[19] = ((limbs[2] >> 50) | (limbs[3] << 1)) as u8;
+        s[20] =  (limbs[3] >>  7)                    as u8;
+        s[21] =  (limbs[3] >> 15)                    as u8;
+        s[22] =  (limbs[3] >> 23)                    as u8;
+        s[23] =  (limbs[3] >> 31)                    as u8;
+        s[24] =  (limbs[3] >> 39)                    as u8;
+        s[25] = ((limbs[3] >> 47) | (limbs[4] << 4)) as u8;
+        s[26] =  (limbs[4] >>  4)                    as u8;
+        s[27] =  (limbs[4] >> 12)                    as u8;
+        s[28] =  (limbs[4] >> 20)                    as u8;
+        s[29] =  (limbs[4] >> 28)                    as u8;
+        s[30] =  (limbs[4] >> 36)                    as u8;
+        s[31] =  (limbs[4] >> 44)                    as u8;
+
+        // High bit should be zero.
+        // DISABLED DUE TO NO VERUS SUPPORT FOR PANICS
+        // debug_assert!((s[31] & 0b1000_0000u8) == 0u8);
+
+        s
+    }
+
+    /// Given `k > 0`, return `self^(2^k)`.
+    #[rustfmt::skip] // keep alignment of c* calculations
+    pub fn pow2k(&self, mut k: u32) -> FieldElement51 {
+
+        // DISABLED DUE TO NO VERUS SUPPORT FOR PANICS
+        // debug_assert!( k > 0 );
+
+
+        let mut a: [u64; 5] = self.limbs;
+
+        loop
+            invariant
+                true
+            decreases k
+        {
+            // Precondition: assume input limbs a[i] are bounded as
+            //
+            // a[i] < 2^(51 + b)
+            //
+            // where b is a real parameter measuring the "bit excess" of the limbs.
+
+            // Precomputation: 64-bit multiply by 19.
+            //
+            // This fits into a u64 whenever 51 + b + lg(19) < 64.
+            //
+            // Since 51 + b + lg(19) < 51 + 4.25 + b
+            //                       = 55.25 + b,
+            // this fits if b < 8.75.
+            let a3_19 = 19 * a[3];
+            let a4_19 = 19 * a[4];
+
+            // Multiply to get 128-bit coefficients of output.
+            //
+            // The 128-bit multiplications by 2 turn into 1 slr + 1 slrd each,
+            // which doesn't seem any better or worse than doing them as precomputations
+            // on the 64-bit inputs.
+            let     c0: u128 = m(a[0],  a[0]) + 2*( m(a[1], a4_19) + m(a[2], a3_19) );
+            let mut c1: u128 = m(a[3], a3_19) + 2*( m(a[0],  a[1]) + m(a[2], a4_19) );
+            let mut c2: u128 = m(a[1],  a[1]) + 2*( m(a[0],  a[2]) + m(a[4], a3_19) );
+            let mut c3: u128 = m(a[4], a4_19) + 2*( m(a[0],  a[3]) + m(a[1],  a[2]) );
+            let mut c4: u128 = m(a[2],  a[2]) + 2*( m(a[0],  a[4]) + m(a[1],  a[3]) );
+
+            // Same bound as in multiply:
+            //    c[i] < 2^(102 + 2*b) * (1+i + (4-i)*19)
+            //         < 2^(102 + lg(1 + 4*19) + 2*b)
+            //         < 2^(108.27 + 2*b)
+            //
+            // The carry (c[i] >> 51) fits into a u64 when
+            //    108.27 + 2*b - 51 < 64
+            //    2*b < 6.73
+            //    b < 3.365.
+            //
+            // So we require b < 3 to ensure this fits.
+            // DISABLED DUE TO NO VERUS SUPPORT FOR PANICS
+            // debug_assert!(a[0] < (1 << 54));
+            // debug_assert!(a[1] < (1 << 54));
+            // debug_assert!(a[2] < (1 << 54));
+            // debug_assert!(a[3] < (1 << 54));
+            // debug_assert!(a[4] < (1 << 54));
+
+            // const LOW_51_BIT_MASK: u64 = (1u64 << 51) - 1; // already defined
+
+            // Casting to u64 and back tells the compiler that the carry is bounded by 2^64, so
+            // that the addition is a u128 + u64 rather than u128 + u128.
+            c1 += ((c0 >> 51) as u64) as u128;
+            a[0] = (c0 as u64) & LOW_51_BIT_MASK;
+
+            c2 += ((c1 >> 51) as u64) as u128;
+            a[1] = (c1 as u64) & LOW_51_BIT_MASK;
+
+            c3 += ((c2 >> 51) as u64) as u128;
+            a[2] = (c2 as u64) & LOW_51_BIT_MASK;
+
+            c4 += ((c3 >> 51) as u64) as u128;
+            a[3] = (c3 as u64) & LOW_51_BIT_MASK;
+
+            let carry: u64 = (c4 >> 51) as u64;
+            a[4] = (c4 as u64) & LOW_51_BIT_MASK;
+
+            // To see that this does not overflow, we need a[0] + carry * 19 < 2^64.
+            //
+            // c4 < a2^2 + 2*a0*a4 + 2*a1*a3 + (carry from c3)
+            //    < 2^(102 + 2*b + lg(5)) + 2^64.
+            //
+            // When b < 3 we get
+            //
+            // c4 < 2^110.33  so that carry < 2^59.33
+            //
+            // so that
+            //
+            // a[0] + carry * 19 < 2^51 + 19 * 2^59.33 < 2^63.58
+            //
+            // and there is no overflow.
+            a[0] += carry * 19;
+
+            // Now a[1] < 2^51 + 2^(64 -51) = 2^51 + 2^13 < 2^(51 + epsilon).
+            a[1] += a[0] >> 51;
+            a[0] &= LOW_51_BIT_MASK;
+
+            // Now all a[i] < 2^(51 + epsilon) and a = self^(2^k).
+
+            k -= 1;
+            if k == 0 {
+                break;
+            }
+        }
+
+        // ADAPTED CODE LINE: limbs is now a named field
+        FieldElement51{limbs: a}
+    }
+
+    /// Returns the square of this field element.
+    pub fn square(&self) -> FieldElement51 {
+        self.pow2k(1)
+    }
+
+    /// Returns 2 times the square of this field element.
+    pub fn square2(&self) -> FieldElement51 {
+        let mut square = self.pow2k(1);
+        for i in 0..5 {
+            square.limbs[i] *= 2;
+        }
+
+        square
+    }
+}
+
+fn main()
+{}
+
+}


### PR DESCRIPTION
Adds characterization of `reduce`:
- It returns bounded limbs
- It's identity on canonical inputs
- It returns an element that represents an equivalent value (mod `p`) in general

as well as non-overflow proofs for `negate`.