### PR TITLE
Check field_verus using `cargo verus verify`

### DIFF
--- a/curve25519-dalek/src/backend/serial/u64/mod.rs
+++ b/curve25519-dalek/src/backend/serial/u64/mod.rs
@@ -27,3 +27,5 @@ pub mod scalar;
 pub mod constants;
 
 pub mod scalar_verus;
+
+pub mod field_verus;


### PR DESCRIPTION
Otherwise not showing up on verilib