### PR TITLE
Change spec to be recursive

### DIFF
--- a/curve25519-dalek/CLAUDE.md
+++ b/curve25519-dalek/CLAUDE.md
@@ -120,11 +120,14 @@ python3 scripts/verus_cleaner.py <file_path> <start_line> <end_line> '<pattern>'
 - `end_line` is inclusive
 - `pattern`: Regex pattern to match statements to test
 
+**Important**: Due to shell interpretation issues, pipe characters (`|`) in regex patterns don't work properly. Use separate commands instead:
+
 #### Examples
 
-**Clean broadcasts and lemmas:**
+**Clean broadcasts and lemmas (run separately):**
 ```bash
-python3 scripts/verus_cleaner.py src/backend/serial/u64/scalar_verus.rs 200 210 'broadcast|lemma'
+python3 scripts/verus_cleaner.py src/backend/serial/u64/scalar_verus.rs 200 210 'broadcast'
+python3 scripts/verus_cleaner.py src/backend/serial/u64/scalar_verus.rs 200 210 'lemma'
 ```
 
 **Clean assert statements:**

--- a/curve25519-dalek/CLAUDE.md
+++ b/curve25519-dalek/CLAUDE.md
@@ -104,3 +104,31 @@ After proving functions completely, clean up redundant assertions before submitt
 - Individual bounds like `assert(m_term1 < (1u128 << 104))` where `m_term1 = m(...)` and the `m()` function postcondition already guarantees the bound
 - Intermediate steps in multi-step calculations where only the final result matters
 - Duplicate calculations that Verus can derive automatically
+
+### 12. Using the Verus Cleaner Script
+
+The `verus_cleaner.py` script automates the process of testing whether proof statements are necessary or redundant. It systematically removes each matching statement, runs verification, and reports which ones can be safely removed.
+
+It must be run from the root `curve25519-dalek`, not from `curve25519-dalek/curve25519-dalek`.
+
+#### Basic Usage
+
+```bash
+python3 scripts/verus_cleaner.py <file_path> <start_line> <end_line> '<pattern>'
+```
+
+- `end_line` is inclusive
+- `pattern`: Regex pattern to match statements to test
+
+#### Examples
+
+**Clean broadcasts and lemmas:**
+```bash
+python3 scripts/verus_cleaner.py src/backend/serial/u64/scalar_verus.rs 200 210 'broadcast|lemma'
+```
+
+**Clean assert statements:**
+```bash
+python3 scripts/verus_cleaner.py src/backend/serial/u64/field_verus.rs 150 200 'assert'
+```
+

--- a/curve25519-dalek/CLAUDE.md
+++ b/curve25519-dalek/CLAUDE.md
@@ -114,7 +114,7 @@ It must be run from the root `curve25519-dalek`, not from `curve25519-dalek/curv
 #### Basic Usage
 
 ```bash
-python3 scripts/verus_cleaner.py <file_path> <start_line> <end_line> '<pattern>'
+scripts/verus_cleaner.py <file_path> <start_line> <end_line> '<pattern>'
 ```
 
 - `end_line` is inclusive
@@ -126,12 +126,12 @@ python3 scripts/verus_cleaner.py <file_path> <start_line> <end_line> '<pattern>'
 
 **Clean broadcasts and lemmas (run separately):**
 ```bash
-python3 scripts/verus_cleaner.py src/backend/serial/u64/scalar_verus.rs 200 210 'broadcast'
-python3 scripts/verus_cleaner.py src/backend/serial/u64/scalar_verus.rs 200 210 'lemma'
+scripts/verus_cleaner.py src/backend/serial/u64/scalar_verus.rs 200 210 'broadcast'
+scripts/verus_cleaner.py src/backend/serial/u64/scalar_verus.rs 200 210 'lemma'
 ```
 
 **Clean assert statements:**
 ```bash
-python3 scripts/verus_cleaner.py src/backend/serial/u64/field_verus.rs 150 200 'assert'
+scripts/verus_cleaner.py src/backend/serial/u64/field_verus.rs 150 200 'assert'
 ```
 

--- a/curve25519-dalek/src/backend/serial/u64/scalar_verus.rs
+++ b/curve25519-dalek/src/backend/serial/u64/scalar_verus.rs
@@ -153,8 +153,36 @@ verus! {
                   ) * pow2(52)
                  ) * pow2(52)
                 ) * pow2(52));
+
+            // Now assert the same thing but with limbs[i] as nat instead of seq[i]
+            assert(seq_to_nat(seq) == 
+                (limbs[0] as nat) + 
+                ((limbs[1] as nat) + 
+                 ((limbs[2] as nat) + 
+                  ((limbs[3] as nat) + 
+                   ((limbs[4] as nat) + 
+                    ((limbs[5] as nat) + 
+                     ((limbs[6] as nat) + 
+                      ((limbs[7] as nat) + 
+                       (limbs[8] as nat) * pow2(52)
+                      ) * pow2(52)
+                     ) * pow2(52)
+                    ) * pow2(52)
+                   ) * pow2(52)
+                  ) * pow2(52)
+                 ) * pow2(52)
+                ) * pow2(52));
             
-            assume(false);
+            lemma_pow2_adds(52, 52);
+            lemma_pow2_adds(52, 104);
+            lemma_pow2_adds(52, 156);
+            lemma_pow2_adds(52, 208);
+            lemma_pow2_adds(52, 260);
+            lemma_pow2_adds(52, 312);
+            lemma_pow2_adds(52, 364);
+            
+            broadcast use group_mul_is_commutative_and_distributive;
+            broadcast use lemma_mul_is_associative;
         }
 
         pub open spec fn to_nat_direct(limbs: [u64; 5]) -> nat {

--- a/curve25519-dalek/src/backend/serial/u64/scalar_verus.rs
+++ b/curve25519-dalek/src/backend/serial/u64/scalar_verus.rs
@@ -127,6 +127,36 @@ verus! {
             (limbs[8] as nat) * pow2(416)
         }
 
+        proof fn lemma_nine_limbs_equals_slice_to_nat128(limbs: &[u128; 9])
+        ensures 
+            nine_limbs_to_nat_direct(limbs) == slice_to_nat128(limbs)
+        {
+            reveal_with_fuel(seq_to_nat, 10);
+            
+            let seq = limbs@.map(|i, x| x as nat);
+            
+            // Assert what seq_to_nat(seq) expands to when fully unfolded
+            assert(seq_to_nat(seq) == 
+                seq[0] + 
+                (seq[1] + 
+                 (seq[2] + 
+                  (seq[3] + 
+                   (seq[4] + 
+                    (seq[5] + 
+                     (seq[6] + 
+                      (seq[7] + 
+                       seq[8] * pow2(52)
+                      ) * pow2(52)
+                     ) * pow2(52)
+                    ) * pow2(52)
+                   ) * pow2(52)
+                  ) * pow2(52)
+                 ) * pow2(52)
+                ) * pow2(52));
+            
+            assume(false);
+        }
+
         pub open spec fn to_nat_direct(limbs: [u64; 5]) -> nat {
             (limbs[0] as nat) +
             pow2(52) * (limbs[1] as nat) +

--- a/curve25519-dalek/src/backend/serial/u64/scalar_verus.rs
+++ b/curve25519-dalek/src/backend/serial/u64/scalar_verus.rs
@@ -625,7 +625,7 @@ verus! {
     requires
         forall|i: int| 0 <= i < 5 ==> a.limbs[i] < (1u64 << 52),
     ensures
-        slice_to_nat128(&z) == to_nat_direct(a.limbs) * to_nat_direct(a.limbs),
+        slice_to_nat128(&z) == slice_to_nat64(&a.limbs) * slice_to_nat64(&a.limbs),
     {
         let mut z = [0u128; 9];
 
@@ -688,6 +688,7 @@ verus! {
                 lemma_pow2_adds(208, 208);
             };
             lemma_nine_limbs_equals_slice_to_nat128(&z);
+            lemma_five_limbs_equals_slice_to_nat64(&a.limbs);
         }
 
         z

--- a/curve25519-dalek/src/backend/serial/u64/scalar_verus.rs
+++ b/curve25519-dalek/src/backend/serial/u64/scalar_verus.rs
@@ -108,7 +108,7 @@ verus! {
 
 
 
-        pub open spec fn nine_limbs_to_nat(limbs: &[u128; 9]) -> nat {
+        pub open spec fn nine_limbs_to_nat_aux(limbs: &[u128; 9]) -> nat {
             (limbs[0] as nat) +
             (limbs[1] as nat) * pow2(52) +
             (limbs[2] as nat) * pow2(104) +
@@ -122,7 +122,7 @@ verus! {
 
         proof fn lemma_nine_limbs_equals_slice128_to_nat(limbs: &[u128; 9])
         ensures 
-            nine_limbs_to_nat(limbs) == slice128_to_nat(limbs)
+            nine_limbs_to_nat_aux(limbs) == slice128_to_nat(limbs)
         {
 
             let seq = limbs@.map(|i, x| x as nat);
@@ -160,13 +160,13 @@ verus! {
                 broadcast use group_mul_is_distributive;
                 broadcast use lemma_mul_is_associative;
                 }
-                nine_limbs_to_nat(limbs);
+                nine_limbs_to_nat_aux(limbs);
             }
         }
 
         proof fn lemma_five_limbs_equals_slice64_to_nat(limbs: &[u64; 5])
         ensures 
-            five_limbs_to_nat(*limbs) == slice64_to_nat(limbs)
+            five_limbs_to_nat_aux(*limbs) == slice64_to_nat(limbs)
         {
             let seq = limbs@.map(|i, x| x as nat);
 
@@ -197,11 +197,11 @@ verus! {
                 pow2(156) * (limbs[3] as nat) +
                 pow2(208) * (limbs[4] as nat); {
                 }
-                five_limbs_to_nat(*limbs);
+                five_limbs_to_nat_aux(*limbs);
             }
         }
 
-        pub open spec fn five_limbs_to_nat(limbs: [u64; 5]) -> nat {
+        pub open spec fn five_limbs_to_nat_aux(limbs: [u64; 5]) -> nat {
             (limbs[0] as nat) +
             pow2(52) * (limbs[1] as nat) +
             pow2(104) * (limbs[2] as nat) +
@@ -598,7 +598,7 @@ verus! {
         z[8] =                                                                 m(a.limbs[4], b.limbs[4]);
 
         proof {
-            assert(five_limbs_to_nat(a.limbs) * five_limbs_to_nat(b.limbs) == nine_limbs_to_nat(&z)) by {
+            assert(five_limbs_to_nat_aux(a.limbs) * five_limbs_to_nat_aux(b.limbs) == nine_limbs_to_nat_aux(&z)) by {
                 broadcast use group_mul_is_commutative_and_distributive;
                 broadcast use lemma_mul_is_associative;
 
@@ -675,7 +675,7 @@ verus! {
 
         proof {
 
-            assert(five_limbs_to_nat(a.limbs) * five_limbs_to_nat(a.limbs) == nine_limbs_to_nat(&z)) by {
+            assert(five_limbs_to_nat_aux(a.limbs) * five_limbs_to_nat_aux(a.limbs) == nine_limbs_to_nat_aux(&z)) by {
                 broadcast use group_mul_is_commutative_and_distributive;
                 broadcast use lemma_mul_is_associative;
 

--- a/curve25519-dalek/src/backend/serial/u64/scalar_verus.rs
+++ b/curve25519-dalek/src/backend/serial/u64/scalar_verus.rs
@@ -157,7 +157,6 @@ verus! {
                   ) * pow2(52)
                  ) * pow2(52)
                 ) * pow2(52); {
-                    // Distribute and use power addition lemmas
 
 
             lemma_pow2_adds(52, 52);

--- a/curve25519-dalek/src/backend/serial/u64/scalar_verus.rs
+++ b/curve25519-dalek/src/backend/serial/u64/scalar_verus.rs
@@ -157,24 +157,22 @@ verus! {
                   ) * pow2(52)
                  ) * pow2(52)
                 ) * pow2(52); {
+                lemma_pow2_adds(52, 52);
+                lemma_pow2_adds(52, 104);
+                lemma_pow2_adds(52, 156);
+                lemma_pow2_adds(52, 208);
+                lemma_pow2_adds(52, 260);
+                lemma_pow2_adds(52, 312);
+                lemma_pow2_adds(52, 364);
 
-
-            lemma_pow2_adds(52, 52);
-            lemma_pow2_adds(52, 104);
-            lemma_pow2_adds(52, 156);
-            lemma_pow2_adds(52, 208);
-            lemma_pow2_adds(52, 260);
-            lemma_pow2_adds(52, 312);
-            lemma_pow2_adds(52, 364);
-
-            lemma_pow2_adds(104, 52);
-            lemma_pow2_adds(156, 52);
-            lemma_pow2_adds(208, 52);
-            lemma_pow2_adds(260, 52);
-            lemma_pow2_adds(312, 52);
-            lemma_pow2_adds(364, 52);
-            broadcast use group_mul_is_commutative_and_distributive;
-            broadcast use lemma_mul_is_associative;
+                lemma_pow2_adds(104, 52);
+                lemma_pow2_adds(156, 52);
+                lemma_pow2_adds(208, 52);
+                lemma_pow2_adds(260, 52);
+                lemma_pow2_adds(312, 52);
+                lemma_pow2_adds(364, 52);
+                broadcast use group_mul_is_commutative_and_distributive;
+                broadcast use lemma_mul_is_associative;
                 }
                 nine_limbs_to_nat_direct(limbs);
             }

--- a/curve25519-dalek/src/backend/serial/u64/scalar_verus.rs
+++ b/curve25519-dalek/src/backend/serial/u64/scalar_verus.rs
@@ -51,23 +51,6 @@ verus! {
         pub const LFACTOR: u64 = 0x51da312547e1b;
 
         /******  SPECIFICATION FUNCTIONS ********/
-
-        // FUTURE VERUS FEATURE: Generic function to convert array of integers to natural number
-        // This is what we would like to have, but Verus doesn't support generic types yet.
-        // When Verus adds generic support, this could replace the concrete u64/u32 versions below.
-        /*
-        pub open spec fn to_nat_gen<T>(limbs: &[T], num_limbs: int, bits_per_limb: int) -> nat
-        decreases num_limbs
-        {
-            if num_limbs <= 0 {
-                0
-            } else {
-                let limb_value = (limbs[num_limbs - 1] as nat) * pow2(((num_limbs - 1) * bits_per_limb) as nat);
-                limb_value + to_nat_gen(limbs, num_limbs - 1, bits_per_limb)
-            }
-        }
-        */
-
         // TODO Remove these?
         // Generic function to convert array of integers to natural number
         // Takes: array of integers, number of limbs, bits per limb
@@ -209,16 +192,6 @@ verus! {
             pow2(208) * (limbs[4] as nat)
         }
 
-        pub open spec fn to_nat_gen_u32(limbs: &[u32], num_limbs: int, bits_per_limb: int) -> nat
-        decreases num_limbs
-        {
-            if num_limbs <= 0 {
-                0
-            } else {
-                let limb_value = (limbs[num_limbs - 1] as nat) * pow2(((num_limbs - 1) * bits_per_limb) as nat);
-                limb_value + to_nat_gen_u32(limbs, num_limbs - 1, bits_per_limb)
-            }
-        }
 
         // Interpret limbs as a little-endian integer with 52-bit limbs
         pub open spec fn to_nat(limbs: &[u64; 5]) -> nat {

--- a/curve25519-dalek/src/backend/serial/u64/scalar_verus.rs
+++ b/curve25519-dalek/src/backend/serial/u64/scalar_verus.rs
@@ -83,6 +83,37 @@ verus! {
             }
         }
 
+        pub open spec fn slice_to_nat(limbs: &[u64]) -> nat
+        {
+            seq_to_nat(limbs@)
+        }
+
+        pub open spec fn seq_to_nat(limbs: Seq<u64>) -> nat
+        decreases limbs.len()
+        {
+            if limbs.len() == 0 {
+                0
+            } else {
+                (limbs[0] as nat) + seq_to_nat(limbs.subrange(1 as int, limbs.len() as int)) * pow2(64)
+            }
+        }
+
+        // pub open spec fn to_nat_gen<T>(limbs: &[T], num_limbs: int, bits_per_limb: int) -> nat
+        // where
+        //     T: core::marker::Copy + Into<nat>
+        // decreases num_limbs
+        // {
+        //     if num_limbs <= 0 {
+        //         0
+        //     } else {
+        //         let limb_value = (limbs[num_limbs - 1] as nat) * pow2(((num_limbs - 1) * bits_per_limb) as nat);
+        //         limb_value + to_nat_gen(limbs, num_limbs - 1, bits_per_limb)
+        //     }
+        // }
+
+
+
+
         // TODO There should be an indirect version
         pub open spec fn nine_limbs_to_nat_direct(limbs: &[u128; 9]) -> nat {
             (limbs[0] as nat) +

--- a/curve25519-dalek/src/backend/serial/u64/scalar_verus.rs
+++ b/curve25519-dalek/src/backend/serial/u64/scalar_verus.rs
@@ -50,7 +50,15 @@ verus! {
         /// `LFACTOR` = (-(L^(-1))) mod 2^52
         pub const LFACTOR: u64 = 0x51da312547e1b;
 
-        /******  SPECIFICATION FUNCTIONS ********/
+        pub open spec fn seq_to_nat(limbs: Seq<nat>) -> nat
+        decreases limbs.len()
+        {
+            if limbs.len() == 0 {
+                0
+            } else {
+                limbs[0] + seq_to_nat(limbs.subrange(1, limbs.len() as int)) * pow2(52)
+            }
+        }
 
         pub open spec fn slice128_to_nat(limbs: &[u128]) -> nat
         {
@@ -62,20 +70,6 @@ verus! {
             seq_to_nat(limbs@.map(|i, x| x as nat))
         }
 
-        pub open spec fn seq_to_nat(limbs: Seq<nat>) -> nat
-        decreases limbs.len()
-        {
-            if limbs.len() == 0 {
-                0
-            } else {
-                limbs[0] + seq_to_nat(limbs.subrange(1, limbs.len() as int)) * pow2(52)
-            }
-        }
-
-
-
-
-
         pub open spec fn nine_limbs_to_nat_aux(limbs: &[u128; 9]) -> nat {
             (limbs[0] as nat) +
             (limbs[1] as nat) * pow2(52) +
@@ -86,6 +80,14 @@ verus! {
             (limbs[6] as nat) * pow2(312) +
             (limbs[7] as nat) * pow2(364) +
             (limbs[8] as nat) * pow2(416)
+        }
+
+        pub open spec fn five_limbs_to_nat_aux(limbs: [u64; 5]) -> nat {
+            (limbs[0] as nat) +
+            pow2(52) * (limbs[1] as nat) +
+            pow2(104) * (limbs[2] as nat) +
+            pow2(156) * (limbs[3] as nat) +
+            pow2(208) * (limbs[4] as nat)
         }
 
         proof fn lemma_nine_limbs_equals_slice128_to_nat(limbs: &[u128; 9])
@@ -167,14 +169,6 @@ verus! {
                 }
                 five_limbs_to_nat_aux(*limbs);
             }
-        }
-
-        pub open spec fn five_limbs_to_nat_aux(limbs: [u64; 5]) -> nat {
-            (limbs[0] as nat) +
-            pow2(52) * (limbs[1] as nat) +
-            pow2(104) * (limbs[2] as nat) +
-            pow2(156) * (limbs[3] as nat) +
-            pow2(208) * (limbs[4] as nat)
         }
 
 

--- a/curve25519-dalek/src/backend/serial/u64/scalar_verus.rs
+++ b/curve25519-dalek/src/backend/serial/u64/scalar_verus.rs
@@ -171,7 +171,8 @@ verus! {
                 lemma_pow2_adds(260, 52);
                 lemma_pow2_adds(312, 52);
                 lemma_pow2_adds(364, 52);
-                broadcast use group_mul_is_commutative_and_distributive;
+                broadcast use group_mul_is_distributive;
+                broadcast use lemma_mul_is_commutative;
                 broadcast use lemma_mul_is_associative;
                 }
                 nine_limbs_to_nat_direct(limbs);

--- a/curve25519-dalek/src/backend/serial/u64/scalar_verus.rs
+++ b/curve25519-dalek/src/backend/serial/u64/scalar_verus.rs
@@ -68,6 +68,7 @@ verus! {
         }
         */
 
+        // TODO Remove these?
         // Generic function to convert array of integers to natural number
         // Takes: array of integers, number of limbs, bits per limb
         // Note: Generic types not supported in Verus yet.
@@ -556,6 +557,7 @@ verus! {
         forall|i: int| 0 <= i < 5 ==> a.limbs[i] < (1u64 << 52),
         forall|i: int| 0 <= i < 5 ==> b.limbs[i] < (1u64 << 52),
     ensures
+            // TODO Update this one
         nine_limbs_to_nat_direct(&z) == to_nat_direct(a.limbs) * to_nat_direct(b.limbs),
     {
         let mut z = [0u128; 9];
@@ -625,6 +627,7 @@ verus! {
     requires
         forall|i: int| 0 <= i < 5 ==> a.limbs[i] < (1u64 << 52),
     ensures
+        // TODO These functions need better names
         slice_to_nat128(&z) == slice_to_nat64(&a.limbs) * slice_to_nat64(&a.limbs),
     {
         let mut z = [0u128; 9];

--- a/curve25519-dalek/src/backend/serial/u64/scalar_verus.rs
+++ b/curve25519-dalek/src/backend/serial/u64/scalar_verus.rs
@@ -196,17 +196,6 @@ verus! {
             broadcast use group_mul_is_commutative_and_distributive;
             broadcast use lemma_mul_is_associative;
                 }
-                (limbs[0] as nat) +
-                (limbs[1] as nat) * pow2(52) +
-                (limbs[2] as nat) * pow2(104) +
-                (limbs[3] as nat) * pow2(156) +
-                (limbs[4] as nat) * pow2(208) +
-                (limbs[5] as nat) * pow2(260) +
-                (limbs[6] as nat) * pow2(312) +
-                (limbs[7] as nat) * pow2(364) +
-                (limbs[8] as nat) * pow2(416); {
-                    // This is exactly nine_limbs_to_nat_direct
-                }
                 nine_limbs_to_nat_direct(limbs);
             }
         }

--- a/curve25519-dalek/src/backend/serial/u64/scalar_verus.rs
+++ b/curve25519-dalek/src/backend/serial/u64/scalar_verus.rs
@@ -158,12 +158,6 @@ verus! {
                  ) * pow2(52)
                 ) * pow2(52); {
                 lemma_pow2_adds(52, 52);
-                lemma_pow2_adds(52, 104);
-                lemma_pow2_adds(52, 156);
-                lemma_pow2_adds(52, 208);
-                lemma_pow2_adds(52, 260);
-                lemma_pow2_adds(52, 312);
-                lemma_pow2_adds(52, 364);
 
                 lemma_pow2_adds(104, 52);
                 lemma_pow2_adds(156, 52);
@@ -172,7 +166,6 @@ verus! {
                 lemma_pow2_adds(312, 52);
                 lemma_pow2_adds(364, 52);
                 broadcast use group_mul_is_distributive;
-                broadcast use lemma_mul_is_commutative;
                 broadcast use lemma_mul_is_associative;
                 }
                 nine_limbs_to_nat_direct(limbs);

--- a/curve25519-dalek/src/backend/serial/u64/scalar_verus.rs
+++ b/curve25519-dalek/src/backend/serial/u64/scalar_verus.rs
@@ -131,12 +131,17 @@ verus! {
         ensures 
             nine_limbs_to_nat_direct(limbs) == slice_to_nat128(limbs)
         {
-            reveal_with_fuel(seq_to_nat, 10);
-            
+
             let seq = limbs@.map(|i, x| x as nat);
-            
-            // Assert what seq_to_nat(seq) expands to when fully unfolded
-            assert(seq_to_nat(seq) == 
+
+            calc! {
+                (==)
+                slice_to_nat128(limbs); {
+                    // slice_to_nat128 = seq_to_nat of mapped sequence
+                }
+                seq_to_nat(seq); {
+                    reveal_with_fuel(seq_to_nat, 10);
+                }
                 seq[0] + 
                 (seq[1] + 
                  (seq[2] + 
@@ -152,10 +157,9 @@ verus! {
                    ) * pow2(52)
                   ) * pow2(52)
                  ) * pow2(52)
-                ) * pow2(52));
-
-            // Now assert the same thing but with limbs[i] as nat instead of seq[i]
-            assert(seq_to_nat(seq) == 
+                ) * pow2(52); {
+                    // Replace seq[i] with (limbs[i] as nat)
+                }
                 (limbs[0] as nat) + 
                 ((limbs[1] as nat) + 
                  ((limbs[2] as nat) + 
@@ -171,8 +175,10 @@ verus! {
                    ) * pow2(52)
                   ) * pow2(52)
                  ) * pow2(52)
-                ) * pow2(52));
-            
+                ) * pow2(52); {
+                    // Distribute and use power addition lemmas
+
+
             lemma_pow2_adds(52, 52);
             lemma_pow2_adds(52, 104);
             lemma_pow2_adds(52, 156);
@@ -180,9 +186,24 @@ verus! {
             lemma_pow2_adds(52, 260);
             lemma_pow2_adds(52, 312);
             lemma_pow2_adds(52, 364);
-            
+
             broadcast use group_mul_is_commutative_and_distributive;
             broadcast use lemma_mul_is_associative;
+                     assume(false);
+                }
+                (limbs[0] as nat) +
+                (limbs[1] as nat) * pow2(52) +
+                (limbs[2] as nat) * pow2(104) +
+                (limbs[3] as nat) * pow2(156) +
+                (limbs[4] as nat) * pow2(208) +
+                (limbs[5] as nat) * pow2(260) +
+                (limbs[6] as nat) * pow2(312) +
+                (limbs[7] as nat) * pow2(364) +
+                (limbs[8] as nat) * pow2(416); {
+                    // This is exactly nine_limbs_to_nat_direct
+                }
+                nine_limbs_to_nat_direct(limbs);
+            }
         }
 
         pub open spec fn to_nat_direct(limbs: [u64; 5]) -> nat {

--- a/curve25519-dalek/src/backend/serial/u64/scalar_verus.rs
+++ b/curve25519-dalek/src/backend/serial/u64/scalar_verus.rs
@@ -83,7 +83,7 @@ verus! {
             }
         }
 
-        pub open spec fn slice_to_nat(limbs: &[u64]) -> nat
+        pub open spec fn slice_to_nat128(limbs: &[u128]) -> nat
         {
             seq_to_nat(limbs@.map(|i, x| x as nat))
         }
@@ -94,7 +94,7 @@ verus! {
             if limbs.len() == 0 {
                 0
             } else {
-                limbs[0] + seq_to_nat(limbs.subrange(1 as int, limbs.len() as int)) * pow2(64)
+                limbs[0] + seq_to_nat(limbs.subrange(1 as int, limbs.len() as int)) * pow2(52)
             }
         }
 

--- a/curve25519-dalek/src/backend/serial/u64/scalar_verus.rs
+++ b/curve25519-dalek/src/backend/serial/u64/scalar_verus.rs
@@ -187,9 +187,14 @@ verus! {
             lemma_pow2_adds(52, 312);
             lemma_pow2_adds(52, 364);
 
+            lemma_pow2_adds(104, 52);
+            lemma_pow2_adds(156, 52);
+            lemma_pow2_adds(208, 52);
+            lemma_pow2_adds(260, 52);
+            lemma_pow2_adds(312, 52);
+            lemma_pow2_adds(364, 52);
             broadcast use group_mul_is_commutative_and_distributive;
             broadcast use lemma_mul_is_associative;
-                     assume(false);
                 }
                 (limbs[0] as nat) +
                 (limbs[1] as nat) * pow2(52) +

--- a/curve25519-dalek/src/backend/serial/u64/scalar_verus.rs
+++ b/curve25519-dalek/src/backend/serial/u64/scalar_verus.rs
@@ -88,6 +88,11 @@ verus! {
             seq_to_nat(limbs@.map(|i, x| x as nat))
         }
 
+        pub open spec fn slice_to_nat64(limbs: &[u64]) -> nat
+        {
+            seq_to_nat(limbs@.map(|i, x| x as nat))
+        }
+
         pub open spec fn seq_to_nat(limbs: Seq<nat>) -> nat
         decreases limbs.len()
         {
@@ -168,6 +173,43 @@ verus! {
                 broadcast use lemma_mul_is_associative;
                 }
                 nine_limbs_to_nat_direct(limbs);
+            }
+        }
+
+        proof fn lemma_five_limbs_equals_slice_to_nat64(limbs: &[u64; 5])
+        ensures 
+            to_nat_direct(*limbs) == slice_to_nat64(limbs)
+        {
+            let seq = limbs@.map(|i, x| x as nat);
+
+            calc! {
+                (==)
+                slice_to_nat64(limbs); {
+                }
+                seq_to_nat(seq); {
+                    reveal_with_fuel(seq_to_nat, 6);
+                }
+                (limbs[0] as nat) +
+                ((limbs[1] as nat) + 
+                 ((limbs[2] as nat) + 
+                  ((limbs[3] as nat) + 
+                   (limbs[4] as nat) * pow2(52)
+                  ) * pow2(52)
+                 ) * pow2(52)
+                ) * pow2(52); {
+                lemma_pow2_adds(52, 52);
+                lemma_pow2_adds(104, 52);
+                lemma_pow2_adds(156, 52);
+                broadcast use group_mul_is_distributive;
+                broadcast use lemma_mul_is_associative;
+                }
+                (limbs[0] as nat) +
+                pow2(52) * (limbs[1] as nat) +
+                pow2(104) * (limbs[2] as nat) +
+                pow2(156) * (limbs[3] as nat) +
+                pow2(208) * (limbs[4] as nat); {
+                }
+                to_nat_direct(*limbs);
             }
         }
 

--- a/curve25519-dalek/src/backend/serial/u64/scalar_verus.rs
+++ b/curve25519-dalek/src/backend/serial/u64/scalar_verus.rs
@@ -103,18 +103,6 @@ verus! {
             }
         }
 
-        // pub open spec fn to_nat_gen<T>(limbs: &[T], num_limbs: int, bits_per_limb: int) -> nat
-        // where
-        //     T: core::marker::Copy + Into<nat>
-        // decreases num_limbs
-        // {
-        //     if num_limbs <= 0 {
-        //         0
-        //     } else {
-        //         let limb_value = (limbs[num_limbs - 1] as nat) * pow2(((num_limbs - 1) * bits_per_limb) as nat);
-        //         limb_value + to_nat_gen(limbs, num_limbs - 1, bits_per_limb)
-        //     }
-        // }
 
 
 

--- a/curve25519-dalek/src/backend/serial/u64/scalar_verus.rs
+++ b/curve25519-dalek/src/backend/serial/u64/scalar_verus.rs
@@ -65,7 +65,7 @@ verus! {
             seq_to_nat(limbs@.map(|i, x| x as nat))
         }
 
-        pub open spec fn slice64_to_nat(limbs: &[u64]) -> nat
+        pub open spec fn to_nat(limbs: &[u64]) -> nat
         {
             seq_to_nat(limbs@.map(|i, x| x as nat))
         }
@@ -134,15 +134,15 @@ verus! {
             }
         }
 
-        proof fn lemma_five_limbs_equals_slice64_to_nat(limbs: &[u64; 5])
+        proof fn lemma_five_limbs_equals_to_nat(limbs: &[u64; 5])
         ensures 
-            five_limbs_to_nat_aux(*limbs) == slice64_to_nat(limbs)
+            five_limbs_to_nat_aux(*limbs) == to_nat(limbs)
         {
             let seq = limbs@.map(|i, x| x as nat);
 
             calc! {
                 (==)
-                slice64_to_nat(limbs); {
+                to_nat(limbs); {
                 }
                 seq_to_nat(seq); {
                     reveal_with_fuel(seq_to_nat, 6);
@@ -175,7 +175,7 @@ verus! {
 
         // Modular reduction of to_nat mod L
         spec fn to_scalar(limbs: &[u64; 5]) -> nat {
-            slice64_to_nat(limbs) % group_order()
+            to_nat(limbs) % group_order()
         }
 
         /// natural value of a 256 bit bitstring represented as array of 32 bytes
@@ -277,7 +277,7 @@ verus! {
         /* ADAPTED CODE LINE: we give a name to the output: "s" */
         pub fn from_bytes(bytes: &[u8; 32]) -> (s: Scalar52)
         // SPECIFICATION: unpacking keeps the same nat value
-        ensures bytes_to_nat(bytes) == slice64_to_nat(&s.limbs)
+        ensures bytes_to_nat(bytes) == to_nat(&s.limbs)
         {
             let mut words = [0u64; 4];
             for i in 0..4
@@ -336,7 +336,7 @@ verus! {
     pub fn to_bytes(self) -> (s: [u8; 32])
     // DIFF-SPEC-3: we give a name to the output: "s"
     // SPECIFICATION: packing keeps the same nat value
-    ensures bytes_to_nat(&s) == slice64_to_nat(&self.limbs)
+    ensures bytes_to_nat(&s) == to_nat(&self.limbs)
     {
         let mut s = [0u8; 32];
 
@@ -384,7 +384,7 @@ verus! {
         forall|i: int| 0 <= i < 5 ==> a.limbs[i] < (1u64 << 52),
         forall|i: int| 0 <= i < 5 ==>  b.limbs[i] < (1u64 << 52),
     ensures
-        slice64_to_nat(&s.limbs) == slice64_to_nat(&a.limbs) + slice64_to_nat(&b.limbs),
+        to_nat(&s.limbs) == to_nat(&a.limbs) + to_nat(&b.limbs),
     {
         //let mut sum = Scalar52::ZERO;
         let mut sum = Scalar52 { limbs: [0u64, 0u64, 0u64, 0u64, 0u64] };
@@ -437,7 +437,7 @@ verus! {
         /*let mut s = Scalar52::sub(&sum, &Self::L);*/
         /* OUR ADAPTED CODE FOR VERUS; PROVED EQUIVALENT TO ORIGINAL CODE */
         let l_value = Scalar52 { limbs: [0x0002631a5cf5d3ed, 0x000dea2f79cd6581, 0x000000000014def9, 0x0000000000000000, 0x0000100000000000] };
-        assert(slice64_to_nat(&l_value.limbs) == slice64_to_nat(&L.limbs));
+        assert(to_nat(&l_value.limbs) == to_nat(&L.limbs));
         assume(false); // TODO: complete the proof
 
         Scalar52::sub(&sum, &l_value)
@@ -452,7 +452,7 @@ verus! {
         forall|i: int| 0 <= i < 5 ==> a.limbs[i] < (1u64 << 52),
         forall|i: int| 0 <= i < 5 ==> b.limbs[i] < (1u64 << 52),
     ensures
-        slice64_to_nat(&s.limbs) == slice64_to_nat(&a.limbs) - slice64_to_nat(&b.limbs),
+        to_nat(&s.limbs) == to_nat(&a.limbs) - to_nat(&b.limbs),
     {
         //let mut difference = Scalar52::ZERO;
          let mut difference = Scalar52 { limbs: [0u64, 0u64, 0u64, 0u64, 0u64] };
@@ -504,7 +504,7 @@ verus! {
         forall|i: int| 0 <= i < 5 ==> a.limbs[i] < (1u64 << 52),
         forall|i: int| 0 <= i < 5 ==> b.limbs[i] < (1u64 << 52),
     ensures
-        slice128_to_nat(&z) == slice64_to_nat(&a.limbs) * slice64_to_nat(&b.limbs),
+        slice128_to_nat(&z) == to_nat(&a.limbs) * to_nat(&b.limbs),
     {
         let mut z = [0u128; 9];
 
@@ -562,8 +562,8 @@ verus! {
                 lemma_pow2_adds(208, 208);
             };
             lemma_nine_limbs_equals_slice128_to_nat(&z);
-            lemma_five_limbs_equals_slice64_to_nat(&a.limbs);
-            lemma_five_limbs_equals_slice64_to_nat(&b.limbs);
+            lemma_five_limbs_equals_to_nat(&a.limbs);
+            lemma_five_limbs_equals_to_nat(&b.limbs);
         }
 
         z
@@ -576,7 +576,7 @@ verus! {
     requires
         forall|i: int| 0 <= i < 5 ==> a.limbs[i] < (1u64 << 52),
     ensures
-        slice128_to_nat(&z) == slice64_to_nat(&a.limbs) * slice64_to_nat(&a.limbs),
+        slice128_to_nat(&z) == to_nat(&a.limbs) * to_nat(&a.limbs),
     {
         let mut z = [0u128; 9];
 
@@ -639,7 +639,7 @@ verus! {
                 lemma_pow2_adds(208, 208);
             };
             lemma_nine_limbs_equals_slice128_to_nat(&z);
-            lemma_five_limbs_equals_slice64_to_nat(&a.limbs);
+            lemma_five_limbs_equals_to_nat(&a.limbs);
         }
 
         z
@@ -652,7 +652,7 @@ verus! {
         forall|i: int| 0 <= i < 5 ==> a.limbs[i] < (1u64 << 52),
         forall|i: int| 0 <= i < 5 ==> b.limbs[i] < (1u64 << 52),
     ensures
-        slice64_to_nat(&result.limbs) == (slice64_to_nat(&a.limbs) * slice64_to_nat(&b.limbs)) % group_order(),
+        to_nat(&result.limbs) == (to_nat(&a.limbs) * to_nat(&b.limbs)) % group_order(),
     {
         assume(false); // TODO: Add proper Montgomery arithmetic proofs
         let ab = Scalar52::montgomery_reduce(&Scalar52::mul_internal(a, b));
@@ -665,7 +665,7 @@ verus! {
     requires
         forall|i: int| 0 <= i < 5 ==> self.limbs[i] < (1u64 << 52),
     ensures
-        slice64_to_nat(&result.limbs) == (slice64_to_nat(&self.limbs) * slice64_to_nat(&self.limbs)) % group_order(),
+        to_nat(&result.limbs) == (to_nat(&self.limbs) * to_nat(&self.limbs)) % group_order(),
     {
         assume(false); // TODO: Add proper Montgomery arithmetic proofs
         let aa = Scalar52::montgomery_reduce(&Scalar52::square_internal(self));
@@ -679,7 +679,7 @@ verus! {
         forall|i: int| 0 <= i < 5 ==> a.limbs[i] < (1u64 << 52),
         forall|i: int| 0 <= i < 5 ==> b.limbs[i] < (1u64 << 52),
     ensures
-        slice64_to_nat(&result.limbs) == (slice64_to_nat(&a.limbs) * slice64_to_nat(&b.limbs)) % group_order(),
+        to_nat(&result.limbs) == (to_nat(&a.limbs) * to_nat(&b.limbs)) % group_order(),
     {
         assume(false); // TODO: Add proper Montgomery arithmetic proofs
         Scalar52::montgomery_reduce(&Scalar52::mul_internal(a, b))
@@ -691,7 +691,7 @@ verus! {
     requires
         forall|i: int| 0 <= i < 5 ==> self.limbs[i] < (1u64 << 52),
     ensures
-        slice64_to_nat(&result.limbs) == (slice64_to_nat(&self.limbs) * slice64_to_nat(&self.limbs)) % group_order(),
+        to_nat(&result.limbs) == (to_nat(&self.limbs) * to_nat(&self.limbs)) % group_order(),
     {
         assume(false); // TODO: Add proper Montgomery arithmetic proofs
         Scalar52::montgomery_reduce(&Scalar52::square_internal(self))

--- a/curve25519-dalek/src/backend/serial/u64/scalar_verus.rs
+++ b/curve25519-dalek/src/backend/serial/u64/scalar_verus.rs
@@ -84,12 +84,12 @@ verus! {
             }
         }
 
-        pub open spec fn slice_to_nat128(limbs: &[u128]) -> nat
+        pub open spec fn slice128_to_nat(limbs: &[u128]) -> nat
         {
             seq_to_nat(limbs@.map(|i, x| x as nat))
         }
 
-        pub open spec fn slice_to_nat64(limbs: &[u64]) -> nat
+        pub open spec fn slice64_to_nat(limbs: &[u64]) -> nat
         {
             seq_to_nat(limbs@.map(|i, x| x as nat))
         }
@@ -120,16 +120,16 @@ verus! {
             (limbs[8] as nat) * pow2(416)
         }
 
-        proof fn lemma_nine_limbs_equals_slice_to_nat128(limbs: &[u128; 9])
+        proof fn lemma_nine_limbs_equals_slice128_to_nat(limbs: &[u128; 9])
         ensures 
-            nine_limbs_to_nat(limbs) == slice_to_nat128(limbs)
+            nine_limbs_to_nat(limbs) == slice128_to_nat(limbs)
         {
 
             let seq = limbs@.map(|i, x| x as nat);
 
             calc! {
                 (==)
-                slice_to_nat128(limbs); {
+                slice128_to_nat(limbs); {
                 }
                 seq_to_nat(seq); {
                     reveal_with_fuel(seq_to_nat, 10);
@@ -164,15 +164,15 @@ verus! {
             }
         }
 
-        proof fn lemma_five_limbs_equals_slice_to_nat64(limbs: &[u64; 5])
+        proof fn lemma_five_limbs_equals_slice64_to_nat(limbs: &[u64; 5])
         ensures 
-            five_limbs_to_nat(*limbs) == slice_to_nat64(limbs)
+            five_limbs_to_nat(*limbs) == slice64_to_nat(limbs)
         {
             let seq = limbs@.map(|i, x| x as nat);
 
             calc! {
                 (==)
-                slice_to_nat64(limbs); {
+                slice64_to_nat(limbs); {
                 }
                 seq_to_nat(seq); {
                     reveal_with_fuel(seq_to_nat, 6);
@@ -556,7 +556,7 @@ verus! {
         forall|i: int| 0 <= i < 5 ==> a.limbs[i] < (1u64 << 52),
         forall|i: int| 0 <= i < 5 ==> b.limbs[i] < (1u64 << 52),
     ensures
-        slice_to_nat128(&z) == slice_to_nat64(&a.limbs) * slice_to_nat64(&b.limbs),
+        slice128_to_nat(&z) == slice64_to_nat(&a.limbs) * slice64_to_nat(&b.limbs),
     {
         let mut z = [0u128; 9];
 
@@ -613,9 +613,9 @@ verus! {
                 lemma_pow2_adds(156, 208);
                 lemma_pow2_adds(208, 208);
             };
-            lemma_nine_limbs_equals_slice_to_nat128(&z);
-            lemma_five_limbs_equals_slice_to_nat64(&a.limbs);
-            lemma_five_limbs_equals_slice_to_nat64(&b.limbs);
+            lemma_nine_limbs_equals_slice128_to_nat(&z);
+            lemma_five_limbs_equals_slice64_to_nat(&a.limbs);
+            lemma_five_limbs_equals_slice64_to_nat(&b.limbs);
         }
 
         z
@@ -628,7 +628,7 @@ verus! {
     requires
         forall|i: int| 0 <= i < 5 ==> a.limbs[i] < (1u64 << 52),
     ensures
-        slice_to_nat128(&z) == slice_to_nat64(&a.limbs) * slice_to_nat64(&a.limbs),
+        slice128_to_nat(&z) == slice64_to_nat(&a.limbs) * slice64_to_nat(&a.limbs),
     {
         let mut z = [0u128; 9];
 
@@ -690,8 +690,8 @@ verus! {
                 lemma_pow2_adds(156, 208);
                 lemma_pow2_adds(208, 208);
             };
-            lemma_nine_limbs_equals_slice_to_nat128(&z);
-            lemma_five_limbs_equals_slice_to_nat64(&a.limbs);
+            lemma_nine_limbs_equals_slice128_to_nat(&z);
+            lemma_five_limbs_equals_slice64_to_nat(&a.limbs);
         }
 
         z

--- a/curve25519-dalek/src/backend/serial/u64/scalar_verus.rs
+++ b/curve25519-dalek/src/backend/serial/u64/scalar_verus.rs
@@ -557,8 +557,7 @@ verus! {
         forall|i: int| 0 <= i < 5 ==> a.limbs[i] < (1u64 << 52),
         forall|i: int| 0 <= i < 5 ==> b.limbs[i] < (1u64 << 52),
     ensures
-            // TODO Update this one
-        nine_limbs_to_nat_direct(&z) == to_nat_direct(a.limbs) * to_nat_direct(b.limbs),
+        slice_to_nat128(&z) == slice_to_nat64(&a.limbs) * slice_to_nat64(&b.limbs),
     {
         let mut z = [0u128; 9];
 
@@ -615,6 +614,9 @@ verus! {
                 lemma_pow2_adds(156, 208);
                 lemma_pow2_adds(208, 208);
             };
+            lemma_nine_limbs_equals_slice_to_nat128(&z);
+            lemma_five_limbs_equals_slice_to_nat64(&a.limbs);
+            lemma_five_limbs_equals_slice_to_nat64(&b.limbs);
         }
 
         z

--- a/curve25519-dalek/src/backend/serial/u64/scalar_verus.rs
+++ b/curve25519-dalek/src/backend/serial/u64/scalar_verus.rs
@@ -158,7 +158,6 @@ verus! {
                  ) * pow2(52)
                 ) * pow2(52); {
                 lemma_pow2_adds(52, 52);
-
                 lemma_pow2_adds(104, 52);
                 lemma_pow2_adds(156, 52);
                 lemma_pow2_adds(208, 52);

--- a/curve25519-dalek/src/backend/serial/u64/scalar_verus.rs
+++ b/curve25519-dalek/src/backend/serial/u64/scalar_verus.rs
@@ -625,7 +625,7 @@ verus! {
     requires
         forall|i: int| 0 <= i < 5 ==> a.limbs[i] < (1u64 << 52),
     ensures
-        nine_limbs_to_nat_direct(&z) == to_nat_direct(a.limbs) * to_nat_direct(a.limbs),
+        slice_to_nat128(&z) == to_nat_direct(a.limbs) * to_nat_direct(a.limbs),
     {
         let mut z = [0u128; 9];
 
@@ -687,7 +687,7 @@ verus! {
                 lemma_pow2_adds(156, 208);
                 lemma_pow2_adds(208, 208);
             };
-
+            lemma_nine_limbs_equals_slice_to_nat128(&z);
         }
 
         z

--- a/curve25519-dalek/src/backend/serial/u64/scalar_verus.rs
+++ b/curve25519-dalek/src/backend/serial/u64/scalar_verus.rs
@@ -94,7 +94,7 @@ verus! {
             if limbs.len() == 0 {
                 0
             } else {
-                limbs[0] + seq_to_nat(limbs.subrange(1 as int, limbs.len() as int)) * pow2(52)
+                limbs[0] + seq_to_nat(limbs.subrange(1, limbs.len() as int)) * pow2(52)
             }
         }
 

--- a/curve25519-dalek/src/backend/serial/u64/scalar_verus.rs
+++ b/curve25519-dalek/src/backend/serial/u64/scalar_verus.rs
@@ -91,7 +91,7 @@ verus! {
         }
 
         proof fn lemma_nine_limbs_equals_slice128_to_nat(limbs: &[u128; 9])
-        ensures 
+        ensures
             nine_limbs_to_nat_aux(limbs) == slice128_to_nat(limbs)
         {
 
@@ -105,13 +105,13 @@ verus! {
                     reveal_with_fuel(seq_to_nat, 10);
                 }
                 (limbs[0] as nat) +
-                ((limbs[1] as nat) + 
-                 ((limbs[2] as nat) + 
-                  ((limbs[3] as nat) + 
-                   ((limbs[4] as nat) + 
-                    ((limbs[5] as nat) + 
-                     ((limbs[6] as nat) + 
-                      ((limbs[7] as nat) + 
+                ((limbs[1] as nat) +
+                 ((limbs[2] as nat) +
+                  ((limbs[3] as nat) +
+                   ((limbs[4] as nat) +
+                    ((limbs[5] as nat) +
+                     ((limbs[6] as nat) +
+                      ((limbs[7] as nat) +
                        (limbs[8] as nat) * pow2(52)
                       ) * pow2(52)
                      ) * pow2(52)
@@ -135,7 +135,7 @@ verus! {
         }
 
         proof fn lemma_five_limbs_equals_to_nat(limbs: &[u64; 5])
-        ensures 
+        ensures
             five_limbs_to_nat_aux(*limbs) == to_nat(limbs)
         {
             let seq = limbs@.map(|i, x| x as nat);
@@ -148,9 +148,9 @@ verus! {
                     reveal_with_fuel(seq_to_nat, 6);
                 }
                 (limbs[0] as nat) +
-                ((limbs[1] as nat) + 
-                 ((limbs[2] as nat) + 
-                  ((limbs[3] as nat) + 
+                ((limbs[1] as nat) +
+                 ((limbs[2] as nat) +
+                  ((limbs[3] as nat) +
                    (limbs[4] as nat) * pow2(52)
                   ) * pow2(52)
                  ) * pow2(52)

--- a/curve25519-dalek/src/backend/serial/u64/scalar_verus.rs
+++ b/curve25519-dalek/src/backend/serial/u64/scalar_verus.rs
@@ -141,25 +141,7 @@ verus! {
                 seq_to_nat(seq); {
                     reveal_with_fuel(seq_to_nat, 10);
                 }
-                seq[0] + 
-                (seq[1] + 
-                 (seq[2] + 
-                  (seq[3] + 
-                   (seq[4] + 
-                    (seq[5] + 
-                     (seq[6] + 
-                      (seq[7] + 
-                       seq[8] * pow2(52)
-                      ) * pow2(52)
-                     ) * pow2(52)
-                    ) * pow2(52)
-                   ) * pow2(52)
-                  ) * pow2(52)
-                 ) * pow2(52)
-                ) * pow2(52); {
-                    // Replace seq[i] with (limbs[i] as nat)
-                }
-                (limbs[0] as nat) + 
+                (limbs[0] as nat) +
                 ((limbs[1] as nat) + 
                  ((limbs[2] as nat) + 
                   ((limbs[3] as nat) + 

--- a/curve25519-dalek/src/backend/serial/u64/scalar_verus.rs
+++ b/curve25519-dalek/src/backend/serial/u64/scalar_verus.rs
@@ -137,7 +137,6 @@ verus! {
             calc! {
                 (==)
                 slice_to_nat128(limbs); {
-                    // slice_to_nat128 = seq_to_nat of mapped sequence
                 }
                 seq_to_nat(seq); {
                     reveal_with_fuel(seq_to_nat, 10);

--- a/curve25519-dalek/src/backend/serial/u64/scalar_verus.rs
+++ b/curve25519-dalek/src/backend/serial/u64/scalar_verus.rs
@@ -108,8 +108,7 @@ verus! {
 
 
 
-        // TODO There should be an indirect version
-        pub open spec fn nine_limbs_to_nat_direct(limbs: &[u128; 9]) -> nat {
+        pub open spec fn nine_limbs_to_nat(limbs: &[u128; 9]) -> nat {
             (limbs[0] as nat) +
             (limbs[1] as nat) * pow2(52) +
             (limbs[2] as nat) * pow2(104) +
@@ -123,7 +122,7 @@ verus! {
 
         proof fn lemma_nine_limbs_equals_slice_to_nat128(limbs: &[u128; 9])
         ensures 
-            nine_limbs_to_nat_direct(limbs) == slice_to_nat128(limbs)
+            nine_limbs_to_nat(limbs) == slice_to_nat128(limbs)
         {
 
             let seq = limbs@.map(|i, x| x as nat);
@@ -161,13 +160,13 @@ verus! {
                 broadcast use group_mul_is_distributive;
                 broadcast use lemma_mul_is_associative;
                 }
-                nine_limbs_to_nat_direct(limbs);
+                nine_limbs_to_nat(limbs);
             }
         }
 
         proof fn lemma_five_limbs_equals_slice_to_nat64(limbs: &[u64; 5])
         ensures 
-            to_nat_direct(*limbs) == slice_to_nat64(limbs)
+            five_limbs_to_nat(*limbs) == slice_to_nat64(limbs)
         {
             let seq = limbs@.map(|i, x| x as nat);
 
@@ -198,11 +197,11 @@ verus! {
                 pow2(156) * (limbs[3] as nat) +
                 pow2(208) * (limbs[4] as nat); {
                 }
-                to_nat_direct(*limbs);
+                five_limbs_to_nat(*limbs);
             }
         }
 
-        pub open spec fn to_nat_direct(limbs: [u64; 5]) -> nat {
+        pub open spec fn five_limbs_to_nat(limbs: [u64; 5]) -> nat {
             (limbs[0] as nat) +
             pow2(52) * (limbs[1] as nat) +
             pow2(104) * (limbs[2] as nat) +
@@ -599,7 +598,7 @@ verus! {
         z[8] =                                                                 m(a.limbs[4], b.limbs[4]);
 
         proof {
-            assert(to_nat_direct(a.limbs) * to_nat_direct(b.limbs) == nine_limbs_to_nat_direct(&z)) by {
+            assert(five_limbs_to_nat(a.limbs) * five_limbs_to_nat(b.limbs) == nine_limbs_to_nat(&z)) by {
                 broadcast use group_mul_is_commutative_and_distributive;
                 broadcast use lemma_mul_is_associative;
 
@@ -629,7 +628,6 @@ verus! {
     requires
         forall|i: int| 0 <= i < 5 ==> a.limbs[i] < (1u64 << 52),
     ensures
-        // TODO These functions need better names
         slice_to_nat128(&z) == slice_to_nat64(&a.limbs) * slice_to_nat64(&a.limbs),
     {
         let mut z = [0u128; 9];
@@ -677,7 +675,7 @@ verus! {
 
         proof {
 
-            assert(to_nat_direct(a.limbs) * to_nat_direct(a.limbs) == nine_limbs_to_nat_direct(&z)) by {
+            assert(five_limbs_to_nat(a.limbs) * five_limbs_to_nat(a.limbs) == nine_limbs_to_nat(&z)) by {
                 broadcast use group_mul_is_commutative_and_distributive;
                 broadcast use lemma_mul_is_associative;
 

--- a/curve25519-dalek/src/backend/serial/u64/scalar_verus.rs
+++ b/curve25519-dalek/src/backend/serial/u64/scalar_verus.rs
@@ -85,16 +85,16 @@ verus! {
 
         pub open spec fn slice_to_nat(limbs: &[u64]) -> nat
         {
-            seq_to_nat(limbs@)
+            seq_to_nat(limbs@.map(|i, x| x as nat))
         }
 
-        pub open spec fn seq_to_nat(limbs: Seq<u64>) -> nat
+        pub open spec fn seq_to_nat(limbs: Seq<nat>) -> nat
         decreases limbs.len()
         {
             if limbs.len() == 0 {
                 0
             } else {
-                (limbs[0] as nat) + seq_to_nat(limbs.subrange(1 as int, limbs.len() as int)) * pow2(64)
+                limbs[0] + seq_to_nat(limbs.subrange(1 as int, limbs.len() as int)) * pow2(64)
             }
         }
 


### PR DESCRIPTION
Changed the mul_internal and square_internal specs to use recursive-style functions instead of functions that explicitly multiply out the terms (e.g. seq_to_nat vs nine_limbs_to_nat_aux). Max prefers this recursive style because he says it's more readable. The mul_internal and square_internal proofs need to manipulate all the terms, so I've added two lemmas that convert the recursive-style spec to the multiplied-out spec

Also added some information on how to run the verus_cleaner script