### PR TITLE
Add `mod p` specs

### DIFF
--- a/curve25519-dalek/src/backend/serial/u64/field_verus.rs
+++ b/curve25519-dalek/src/backend/serial/u64/field_verus.rs
@@ -729,25 +729,10 @@ impl FieldElement51 {
             36028797018963952u64 - self.limbs[4],
         ]);
         proof {
-            // Prove the modular arithmetic postcondition
-            // We need to prove: (as_nat(neg.limbs) + as_nat(old(self).limbs)) % p() == 0
-            
-            // Prove p() > 0
             pow255_gt_19();
             assert(p() > 0);
-            
-            // From the postcondition stated in ensures clause:
-            // as_nat(self.limbs) == 16 * p() - as_nat(old(self).limbs) - p() * ((36028797018963952u64 - old(self).limbs[4]) as u64 >> 51)
-            // Since self.limbs = neg.limbs at the end, this means:
-            // as_nat(neg.limbs) == 16 * p() - as_nat(old(self).limbs) - p() * k  where k = ((36028797018963952u64 - old(self).limbs[4]) as u64 >> 51)
-            
             let k = ((36028797018963952u64 - old(self).limbs[4]) as u64 >> 51) as nat;
             assert(as_nat(neg.limbs) == 16 * p() - as_nat(old(self).limbs) - p() * k);
-            
-            // Rearranging:
-            // as_nat(neg.limbs) + as_nat(old(self).limbs) == 16 * p() - p() * k
-            // as_nat(neg.limbs) + as_nat(old(self).limbs) == p() * (16 - k)
-            
             calc! {
                 (==)
                 (as_nat(neg.limbs) + as_nat(old(self).limbs)) as int; {}
@@ -757,12 +742,8 @@ impl FieldElement51 {
                 }
                 (p() * (16 - k)) as int;
             }
-            
-            // Now show that p() * (16 - k) % p() == 0
             lemma_mod_multiples_vanish((16 - k) as int, 0 as int, p() as int);
             assert(((p() * (16 - k)) as int) % (p() as int) == 0);
-            
-            // Therefore:
             assert(((as_nat(neg.limbs) + as_nat(old(self).limbs)) as int) % (p() as int) == 0);
         }
         self.limbs = neg.limbs;
@@ -781,15 +762,9 @@ impl FieldElement51 {
         proof {
             lemma_boundaries(limbs);
             lemma_reduce(limbs);
-            // Prove p() > 0 for the precondition of lemma_mod_multiples_vanish
             pow255_gt_19();
             assert(p() == pow2(255) - 19);
             assert(p() > 0);
-            // Prove modular equivalence using vstd lemma
-            // lemma_reduce proves: as_nat(spec_reduce(limbs)) == as_nat(limbs) - p() * (limbs[4] >> 51)
-            // Which means: as_nat(limbs) == as_nat(spec_reduce(limbs)) + p() * (limbs[4] >> 51)
-            // We need to prove: as_nat(spec_reduce(limbs)) % p() == as_nat(limbs) % p()
-            // Using lemma_mod_multiples_vanish: ((m * a + b) % m) == b % m
             lemma_mod_multiples_vanish((limbs[4] >> 51) as int, as_nat(spec_reduce(limbs)) as int, p() as int);
         }
 

--- a/curve25519-dalek/src/backend/serial/u64/field_verus.rs
+++ b/curve25519-dalek/src/backend/serial/u64/field_verus.rs
@@ -737,7 +737,8 @@ impl FieldElement51 {
             r.limbs == spec_reduce(limbs),
             forall|i: int| 0 <= i < 5 ==> r.limbs[i] < (1u64 << 52),
             (forall|i: int| 0 <= i < 5 ==> limbs[i] < (1u64 << 51)) ==> (r.limbs =~= limbs),
-            as_nat(r.limbs) == as_nat(limbs) - p() * (limbs[4] >> 51)
+            as_nat(r.limbs) == as_nat(limbs) - p() * (limbs[4] >> 51),
+            as_nat(r.limbs) % p() == as_nat(limbs) % p()
     {
         proof {
             lemma_boundaries(limbs);

--- a/curve25519-dalek/src/backend/serial/u64/field_verus.rs
+++ b/curve25519-dalek/src/backend/serial/u64/field_verus.rs
@@ -750,8 +750,6 @@ impl FieldElement51 {
             lemma_boundaries(limbs);
             lemma_reduce(limbs);
             pow255_gt_19();
-            assert(p() == pow2(255) - 19);
-            assert(p() > 0);
             lemma_mod_multiples_vanish((limbs[4] >> 51) as int, as_nat(spec_reduce(limbs)) as int, p() as int);
         }
 

--- a/curve25519-dalek/src/backend/serial/u64/field_verus.rs
+++ b/curve25519-dalek/src/backend/serial/u64/field_verus.rs
@@ -730,9 +730,7 @@ impl FieldElement51 {
         ]);
         proof {
             let k = ((36028797018963952u64 - old(self).limbs[4]) as u64 >> 51) as nat;
-            assert(16 * p() - p() * k == p() * (16 - k)) by {
-                broadcast use lemma_mul_is_distributive_sub;
-            }
+            broadcast use lemma_mul_is_distributive_sub;
             lemma_mod_multiples_vanish((16 - k) as int, 0 as int, p() as int);
         }
         self.limbs = neg.limbs;

--- a/curve25519-dalek/src/backend/serial/u64/field_verus.rs
+++ b/curve25519-dalek/src/backend/serial/u64/field_verus.rs
@@ -645,7 +645,8 @@ impl FieldElement51 {
             // as_nat(negate(l)) = as_nat(reduce(16 * (c0, c, c, c, c) - l))
             //                   = 16p - as_nat(l) - p * ((16c - l4) >> 51)
             // Note that (16c - l4) >> 51 is either 14 or 15, in either case < 16.
-            as_nat(self.limbs) == 16 * p() - as_nat(old(self).limbs) - p() * ((36028797018963952u64 - old(self).limbs[4]) as u64 >> 51)
+            as_nat(self.limbs) == 16 * p() - as_nat(old(self).limbs) - p() * ((36028797018963952u64 - old(self).limbs[4]) as u64 >> 51),
+            (as_nat(self.limbs) + as_nat(old(self).limbs)) % p() == 0
             // Reducing mod p, this implies `as_nat(self.limbs) == - as_nat(old(self).limbs)`
     {
         proof {

--- a/curve25519-dalek/src/backend/serial/u64/field_verus.rs
+++ b/curve25519-dalek/src/backend/serial/u64/field_verus.rs
@@ -729,22 +729,15 @@ impl FieldElement51 {
             36028797018963952u64 - self.limbs[4],
         ]);
         proof {
-            pow255_gt_19();
-            assert(p() > 0);
             let k = ((36028797018963952u64 - old(self).limbs[4]) as u64 >> 51) as nat;
-            assert(as_nat(neg.limbs) == 16 * p() - as_nat(old(self).limbs) - p() * k);
             calc! {
                 (==)
-                (as_nat(neg.limbs) + as_nat(old(self).limbs)) as int; {}
-                (16 * p() - as_nat(old(self).limbs) - p() * k + as_nat(old(self).limbs)) as int; {}
                 (16 * p() - p() * k) as int; {
                     lemma_mul_is_distributive_sub(p() as int, 16 as int, k as int);
                 }
                 (p() * (16 - k)) as int;
             }
             lemma_mod_multiples_vanish((16 - k) as int, 0 as int, p() as int);
-            assert(((p() * (16 - k)) as int) % (p() as int) == 0);
-            assert(((as_nat(neg.limbs) + as_nat(old(self).limbs)) as int) % (p() as int) == 0);
         }
         self.limbs = neg.limbs;
     }

--- a/curve25519-dalek/src/backend/serial/u64/field_verus.rs
+++ b/curve25519-dalek/src/backend/serial/u64/field_verus.rs
@@ -743,6 +743,16 @@ impl FieldElement51 {
         proof {
             lemma_boundaries(limbs);
             lemma_reduce(limbs);
+            // Prove p() > 0 for the precondition of lemma_mod_multiples_vanish
+            pow255_gt_19();
+            assert(p() == pow2(255) - 19);
+            assert(p() > 0);
+            // Prove modular equivalence using vstd lemma
+            // lemma_reduce proves: as_nat(spec_reduce(limbs)) == as_nat(limbs) - p() * (limbs[4] >> 51)
+            // Which means: as_nat(limbs) == as_nat(spec_reduce(limbs)) + p() * (limbs[4] >> 51)
+            // We need to prove: as_nat(spec_reduce(limbs)) % p() == as_nat(limbs) % p()
+            // Using lemma_mod_multiples_vanish: ((m * a + b) % m) == b % m
+            lemma_mod_multiples_vanish((limbs[4] >> 51) as int, as_nat(spec_reduce(limbs)) as int, p() as int);
         }
 
         // Since the input limbs are bounded by 2^64, the biggest

--- a/curve25519-dalek/src/backend/serial/u64/field_verus.rs
+++ b/curve25519-dalek/src/backend/serial/u64/field_verus.rs
@@ -647,7 +647,6 @@ impl FieldElement51 {
             // Note that (16c - l4) >> 51 is either 14 or 15, in either case < 16.
             as_nat(self.limbs) == 16 * p() - as_nat(old(self).limbs) - p() * ((36028797018963952u64 - old(self).limbs[4]) as u64 >> 51),
             (as_nat(self.limbs) + as_nat(old(self).limbs)) % p() == 0
-            // Reducing mod p, this implies `as_nat(self.limbs) == - as_nat(old(self).limbs)`
     {
         proof {
             let c0 = (pow2(51) - 19);

--- a/curve25519-dalek/src/backend/serial/u64/field_verus.rs
+++ b/curve25519-dalek/src/backend/serial/u64/field_verus.rs
@@ -730,12 +730,8 @@ impl FieldElement51 {
         ]);
         proof {
             let k = ((36028797018963952u64 - old(self).limbs[4]) as u64 >> 51) as nat;
-            calc! {
-                (==)
-                (16 * p() - p() * k) as int; {
-                    lemma_mul_is_distributive_sub(p() as int, 16 as int, k as int);
-                }
-                (p() * (16 - k)) as int;
+            assert(16 * p() - p() * k == p() * (16 - k)) by {
+                broadcast use lemma_mul_is_distributive_sub;
             }
             lemma_mod_multiples_vanish((16 - k) as int, 0 as int, p() as int);
         }


### PR DESCRIPTION
The interesting thing here is that Opus was able to figure out the proofs on autopilot. e.g. it produced [1a7b057](https://github.com/Beneficial-AI-Foundation/curve25519-dalek/pull/22/commits/1a7b057c31da5239aa7e69c8b992eeef3aeec656) from this prompt:

> Run `cargo verus verify -- --verify-only-module backend::serial::u64::field_verus --verify-function FieldElement51::reduce`. I think you might need to use lemmas from
https://verus-lang.github.io/verus/verusdoc/vstd/arithmetic/div_mod/index.html to prove it.
Sonnet previously tried but couldn't find a perfect lemma. I suspect you might need a
combination of lemmas in a calc statement. If a calc statement is failing, put in assumes to
figure out which equality is failing. But your final answer can't use assumes. notify-send me
when done

This is still a pretty heavy hint, but I didn't have to intervene while it was working

Note that Sonnet had tried and failed previously, although Opus couldn't see Sonnet's attempt or the chat history.

Opus cost $7.84

I then used `verus_cleaner.py` to shorten the proof, and I changed a calc statement to a broadcast