### PR TITLE
Fix CI

### DIFF
--- a/.github/workflows/curve25519-dalek.yml
+++ b/.github/workflows/curve25519-dalek.yml
@@ -130,14 +130,8 @@ jobs:
       uses: dtolnay/rust-toolchain@1.88.0
     - name: Install Verus
       run: |
-        curl https://api.github.com/repos/verus-lang/verus/releases/latest > releases.txt
-        echo Printing releases.txt
-        cat releases.txt
-        LATEST_RELEASE=$(cat releases.txt | grep '"tag_name"' | sed -E 's/.*"([^"]+)".*/\1/')
-        echo Latest release is $LATEST_RELEASE
-        DOWNLOAD_URL="https://github.com/verus-lang/verus/releases/download/${LATEST_RELEASE}/verus-${LATEST_RELEASE#release/}-x86-linux.zip"
-        wget $DOWNLOAD_URL
-        unzip verus-${LATEST_RELEASE#release/}-x86-linux.zip
+        wget https://github.com/verus-lang/verus/releases/download/release%2Frolling%2F0.2025.07.30.2496084/verus-0.2025.07.30.2496084-x86-linux.zip
+        unzip verus-0.2025.07.30.2496084-x86-linux.zip
         mv verus-x86-linux ~/.cargo/bin
         cd ~/.cargo/bin
         ln -s verus-x86-linux/cargo-verus

--- a/curve25519-dalek/Cargo.toml
+++ b/curve25519-dalek/Cargo.toml
@@ -53,9 +53,9 @@ harness = false
 required-features = ["alloc", "rand_core"]
 
 [dependencies]
-vstd = { git = "https://github.com/verus-lang/verus" }
-verus_builtin = { git = "https://github.com/verus-lang/verus" }
-verus_builtin_macros = { git = "https://github.com/verus-lang/verus" }
+vstd = { git = "https://github.com/verus-lang/verus", rev = "2496084"}
+verus_builtin = { git = "https://github.com/verus-lang/verus", rev = "2496084"}
+verus_builtin_macros = { git = "https://github.com/verus-lang/verus", rev = "2496084"}
 cfg-if = "1"
 ff = { version = "=0.14.0-pre.0", default-features = false, optional = true }
 group = { version = "=0.14.0-pre.0", default-features = false, optional = true }

--- a/curve25519-dalek/Cargo.toml
+++ b/curve25519-dalek/Cargo.toml
@@ -54,8 +54,8 @@ required-features = ["alloc", "rand_core"]
 
 [dependencies]
 vstd = { git = "https://github.com/verus-lang/verus" }
-builtin = { git = "https://github.com/verus-lang/verus" }
-builtin_macros = { git = "https://github.com/verus-lang/verus" }
+verus_builtin = { git = "https://github.com/verus-lang/verus" }
+verus_builtin_macros = { git = "https://github.com/verus-lang/verus" }
 cfg-if = "1"
 ff = { version = "=0.14.0-pre.0", default-features = false, optional = true }
 group = { version = "=0.14.0-pre.0", default-features = false, optional = true }


### PR DESCRIPTION
See https://beneficialaif-jlt4758.slack.com/archives/C095PJN6S02/p1753948553655869. In summary, https://github.com/verus-lang/verus/pull/1815 just got merged, which means we have to use the latest pre-release (not just the latest weekly release) and change the name of two of the crates

Stackoverflow [says](https://stackoverflow.com/questions/67688662/how-can-i-get-the-latest-pre-release-release-for-my-github-repo-bash#comment136993980_67689318) there's no reliable automated way to get the latest pre-release, so I've taken the easy way out and just pinned to this pre-release (and hence I had to pin in Cargo.toml). We could remove the pin once there's a weekly release that includes https://github.com/verus-lang/verus/pull/1815 

Another way to fix CI would be to pin to the commit before https://github.com/verus-lang/verus/pull/1815 
