### PR TITLE
Proof that `pow2k` returns the correct value

### DIFF
--- a/curve25519-dalek/src/backend/serial/u64/common_verus.rs
+++ b/curve25519-dalek/src/backend/serial/u64/common_verus.rs
@@ -356,6 +356,7 @@ pub proof fn masked_lt(v: u64, k: nat)
     shift_is_pow2(k);
 }
 
+// a < b => (2^a - 1) < (2^b - 1)
 pub proof fn low_bits_mask_increases(a: nat, b: nat)
     requires
         a < b
@@ -380,6 +381,7 @@ pub proof fn low_bits_mask_increases(a: nat, b: nat)
 
 }
 
+// k <= 64 => 2^k - 1 <= u64::MAX = 2^64 - 1
 pub proof fn low_bits_masks_fit_u64(k: nat)
     requires
         k <= 64
@@ -436,14 +438,7 @@ pub proof fn lemma_m(x: u64, y: u64, bx: u64, by: u64)
     mul_lt(x as nat, bx as nat, y as nat, by as nat);
 }
 
-pub proof fn lemma_cast_then_mod_51(x: u128)
-    ensures
-        (x as u64) % (pow2(51) as u64) == x % (pow2(51) as u128)
-{
-    lemma2_to64_rest(); // pow2(51 | 64)
-    assert( (x as u64) % 0x8000000000000 == x % 0x8000000000000) by (bit_vector);
-}
-
+// (v^(2^k))^2 = v^(2^(k + 1))
 pub proof fn lemma_pow2_square(v: int, i: nat)
     ensures
         pow(v, pow2(i)) * pow(v, pow2(i)) == pow(v, pow2(i + 1))
@@ -454,6 +449,7 @@ pub proof fn lemma_pow2_square(v: int, i: nat)
     lemma_pow2_unfold(i + 1);
 }
 
+// Combination of mod lemmas, (b +- a * m) % m = b % m
 pub proof fn lemma_mod_sum_factor(a: int, b: int, m: int)
     requires
         m > 0
@@ -468,6 +464,21 @@ pub proof fn lemma_mod_sum_factor(a: int, b: int, m: int)
     lemma_mod_twice(b, m);
 }
 
+pub proof fn lemma_mod_diff_factor(a: int, b: int, m: int)
+    requires
+        m > 0
+    ensures
+        (b - a * m) % m == b % m
+{
+    // (b - a * m) % m == (b % m - (a * m) % m) % m
+    lemma_sub_mod_noop(a * m, b, m);
+    // (a * m) % m == 0
+    lemma_mod_multiples_basic(a, m);
+    // b % m % m = b % m
+    lemma_mod_twice(b, m);
+}
+
+// v^(2^i) >= 0
 pub proof fn lemma_pow_nat_is_nat(v: nat, i: nat)
     ensures
         pow(v as int, pow2(i)) >= 0
@@ -480,59 +491,6 @@ pub proof fn lemma_pow_nat_is_nat(v: nat, i: nat)
         lemma_pow_positive(v as int, pow2(i));
     }
 }
-
-// pub proof fn lemma_cast_then_mod_pow2(x: u128, k: nat)
-//     requires
-//         k < 64
-//     ensures
-//         (x as u64) % (pow2(k) as u64) == x % (pow2(k) as u128)
-// {
-//     // 1. pow2(k) fits in u64
-//     lemma2_to64_rest(); // pow2(63) = 0x8000000000000000
-//     assert(0x8000000000000000 <= u64::MAX) by (compute);
-//     if (k < 63) {
-//         lemma_pow2_strictly_increases(k, 64);
-//     }
-//     // Thus pow2(k) is the same in both types
-//     assert(pow2(k) as u64 == pow2(k) as u128);
-
-//     // x as u64 == x % 2^64
-//     assert((x as u64) == x % 0x10000000000000000) by (bit_vector);
-//     // i.e. assert((x as u64) == (x % (pow2(64) as u128)));
-
-//     // We can write
-//     // x = a + b * 2^64,
-//     // where a < 2^64
-//     // Then, a = (x as u64)
-
-//     // x = x % 2^64 + 2^64 * (x / 2^64)
-//     // conversely, x % 2^64 = x - 2^64 * (x / 2^64)
-//     lemma_fundamental_div_mod(x as int, pow2(64) as int);
-
-//     // We don't care about this bit so we hide it under a symbol
-//     let divCoef = (x / (pow2(64) as u128));
-//     assert((x as u64) == x - pow2(64) * divCoef);
-
-//     assert((x - pow2(64) * divCoef) % (pow2(k) as int) == x % (pow2(k) as u128)) by {
-//         lemma_pow2_pos(k); // pow2(k) > 0
-//         // (x - 2^64 * y) % 2^k = ( x % 2^k  - (2^64 * y) % 2^k ) % 2^k
-//         lemma_sub_mod_noop(x as int, (pow2(64) * divCoef) as int, (pow2(k) as int));
-//         // (2^64 * y) % 2^k = 0 since 2^k | 2^64
-//         assert( (pow2(64) * divCoef) % (pow2(k) as int) == 0) by {
-//             assert(pow2(64) * divCoef == pow2(k) * (pow2((64 - k) as nat) * divCoef)) by {
-//                 // 2^64 = 2^k * 2^(64 - k)
-//                 lemma_pow2_adds(k, (64 - k) as nat);
-//                 broadcast use lemma_mul_is_associative;
-//             }
-
-//             lemma_mod_multiples_basic((pow2((64 - k) as nat) * divCoef) as int, pow2(k) as int);
-//         }
-//         // (x % 2^k) % 2^k = x % 2^k
-//         lemma_mod_twice(x as int, pow2(k) as int );
-//     }
-//     assume(false);
-
-// }
 
 // dummy, so we can call `verus common_verus.rs`
 fn main() {}

--- a/curve25519-dalek/src/backend/serial/u64/field_lemmas.rs
+++ b/curve25519-dalek/src/backend/serial/u64/field_lemmas.rs
@@ -166,6 +166,331 @@ pub proof fn lemma_shr_51_fits_u64(a: u128)
     lemma_shr_51_le(a, (u64::MAX as u128) << 51);
 }
 
+pub proof fn lemma_mod_decomposition(a: nat, b: nat, c: nat, d: nat)
+    requires
+        a > 0
+    ensures
+        (c * (a + b) * d) % a == (c * (b * d)) % a
+{
+    // Hints for the solver
+    assert(a * (c * d) == (c * d) * a);
+
+    assert(b * (c * d) == c * (b * d)) by {
+        broadcast use lemma_mul_is_associative;
+    }
+
+    assert( c * (a + b) * d ==
+        (c * d) * (a + b)
+    ) by {
+        broadcast use lemma_mul_is_associative;
+    }
+
+    assert( (c * d) * (a + b) ==
+        a * (c * d) + b * (c * d)
+    ) by {
+        broadcast use lemma_mul_is_distributive_add;
+    }
+
+    assert((a * (c * d) + b * (c * d)) % a ==
+        (((a * (c * d)) % a) + ((b * (c * d)) % a)) % a
+    ) by {
+        lemma_add_mod_noop((a * (c * d)) as int, (b * (c * d)) as int, a as int);
+    }
+
+    assert((a * (c * d) + b * (c * d)) % a ==
+        ((b * (c * d)) % a) % a ==
+        ((b * (c * d)) % a)
+    ) by {
+        // cd * a % a == 0
+        lemma_mod_multiples_basic((c * d) as int, a as int);
+        broadcast use lemma_mod_twice;
+    }
+
+}
+
+pub proof fn as_nat_squared(v: [u64; 5])
+    ensures
+        as_nat(v) * as_nat(v) ==
+        pow2(8 * 51) * (v[4] * v[4]) +
+        pow2(7 * 51) * (2 * (v[3] * v[4])) +
+        pow2(6 * 51) * (v[3] * v[3] + 2 * (v[2] * v[4])) +
+        pow2(5 * 51) * (2 * (v[2] * v[3]) + 2 * (v[1] * v[4])) +
+        pow2(4 * 51) * (v[2] * v[2] + 2 * (v[1] * v[3]) + 2 * (v[0] * v[4])) +
+        pow2(3 * 51) * (2 * (v[1] * v[2]) + 2 * (v[0] * v[3])) +
+        pow2(2 * 51) * (v[1] * v[1] + 2 * (v[0] * v[2])) +
+        pow2(1 * 51) * (2 * (v[0] * v[1])) +
+                       (v[0] * v[0]),
+        // and the mod equality
+        (as_nat(v) * as_nat(v)) % p() ==
+        (
+            pow2(4 * 51) * (v[2] * v[2] + 2 * (v[1] * v[3]) + 2 * (v[0] * v[4])) +
+            pow2(3 * 51) * (2 * (v[1] *  v[2]) + 2 * (v[0] *  v[3]) + 19 * (v[4] * v[4])) +
+            pow2(2 * 51) * (v[1] * v[1] + 2 * (v[0] *  v[2]) + 19 * (2 * (v[3] * v[4]))) +
+            pow2(1 * 51) * (2 * (v[0] *  v[1]) + 19 * (v[3] * v[3] + 2 * (v[2] * v[4]))) +
+                           (v[0] *  v[0] + 19 * (2 * (v[2] * v[3]) + 2 * (v[1] * v[4])))
+        ) as nat % p()
+{
+    let v0 = v[0];
+    let v1 = v[1];
+    let v2 = v[2];
+    let v3 = v[3];
+    let v4 = v[4];
+
+    let s1 = pow2(1 * 51);
+    let s2 = pow2(2 * 51);
+    let s3 = pow2(3 * 51);
+    let s4 = pow2(4 * 51);
+    let s5 = pow2(5 * 51);
+    let s6 = pow2(6 * 51);
+    let s7 = pow2(7 * 51);
+    let s8 = pow2(8 * 51);
+
+    assert(s1 * s1 == s2) by {
+        lemma_pow2_adds(51, 51)
+    }
+    assert(s1 * s2 == s2 * s1 == s3) by {
+        lemma_pow2_adds(51, 102)
+    }
+    assert(s1 * s3 == s3 * s1 == s4) by {
+        lemma_pow2_adds(51, 153)
+    }
+    assert(s1 * s4 == s4 * s1 == s5) by {
+        lemma_pow2_adds(51, 204)
+    }
+    assert(s2 * s2 ==s4) by {
+        lemma_pow2_adds(102, 102)
+    }
+    assert(s2 * s3 == s3 * s2 == s5) by {
+        lemma_pow2_adds(102, 153)
+    }
+    assert(s2 * s4 == s4 * s2 == s6) by {
+        lemma_pow2_adds(102, 204)
+    }
+    assert(s3 * s3 == s6) by {
+        lemma_pow2_adds(153, 153)
+    }
+    assert(s3 * s4 == s4 * s3 == s7) by {
+        lemma_pow2_adds(153, 204)
+    }
+    assert(s4 * s4 == s8) by {
+        lemma_pow2_adds(204, 204)
+    }
+
+    assert(as_nat(v) * as_nat(v) ==
+        v0 * as_nat(v) +
+        (s1 * v1) * as_nat(v) +
+        (s2 * v2) * as_nat(v) +
+        (s3 * v3) * as_nat(v) +
+        (s4 * v4) * as_nat(v)
+    ) by {
+        broadcast use lemma_mul_is_distributive_add;
+        broadcast use lemma_mul_is_associative;
+    }
+
+    // because of the sheer number of possible associativity/distributivity groupings we have
+    // to help the solver along by intermittently asserting chunks
+    assert(v0 * as_nat(v) ==
+        v0 * v0 +
+        v0 * (s1 * v1) +
+        v0 * (s2 * v2) +
+        v0 * (s3 * v3) +
+        v0 * (s4 * v4)
+        ==
+        s4 * (v0 * v4) +
+        s3 * (v0 * v3) +
+        s2 * (v0 * v2) +
+        s1 * (v0 * v1) +
+        v0 * v0
+    ) by {
+        broadcast use lemma_mul_is_distributive_add;
+        broadcast use lemma_mul_is_associative;
+    }
+
+    assert((s1 * v1) * as_nat(v) ==
+        s5 * (v1 * v4) +
+        s4 * (v1 * v3) +
+        s3 * (v1 * v2) +
+        s2 * (v1 * v1) +
+        s1 * (v0 * v1)
+    ) by {
+        broadcast use lemma_mul_is_distributive_add;
+        broadcast use lemma_mul_is_associative;
+    }
+
+    assert((s2 * v2) * as_nat(v) ==
+        s6 * (v2 * v4) +
+        s5 * (v2 * v3) +
+        s4 * (v2 * v2) +
+        s3 * (v1 * v2) +
+        s2 * (v0 * v2)
+    ) by {
+        broadcast use lemma_mul_is_distributive_add;
+        broadcast use lemma_mul_is_associative;
+    }
+
+    assert((s3 * v3) * as_nat(v) ==
+        s7 * (v3 * v4) +
+        s6 * (v3 * v3) +
+        s5 * (v2 * v3) +
+        s4 * (v1 * v3) +
+        s3 * (v0 * v3)
+    ) by {
+        broadcast use lemma_mul_is_distributive_add;
+        broadcast use lemma_mul_is_associative;
+    }
+
+    assert((s4 * v4) * as_nat(v) ==
+        s8 * (v4 * v4) +
+        s7 * (v3 * v4) +
+        s6 * (v2 * v4) +
+        s5 * (v1 * v4) +
+        s4 * (v0 * v4)
+    ) by {
+        broadcast use lemma_mul_is_distributive_add;
+        broadcast use lemma_mul_is_associative;
+    }
+
+    // we now mash them all together
+    assert(as_nat(v) * as_nat(v) ==
+        s8 * (v4 * v4) +
+        s7 * (2 * (v3 * v4)) +
+        s6 * (v3 * v3 + 2 * (v2 * v4)) +
+        s5 * (2 * (v2 * v3) + 2 * (v1 * v4)) +
+        s4 * (v2 * v2 + 2 * (v1 * v3) + 2 * (v0 * v4)) +
+        s3 * (2 * (v1 * v2) + 2 * (v0 * v3)) +
+        s2 * (v1 * v1 + 2 * (v0 * v2)) +
+        s1 * (2 * (v0 * v1)) +
+             (v0 * v0)
+    ) by {
+        broadcast use lemma_mul_is_associative;
+        broadcast use lemma_mul_is_distributive_add;
+        assert(v0 * v1 + v0 * v1 == 2 * (v0 * v1));
+        assert(v0 * v2 + v0 * v2 == 2 * (v0 * v2));
+        assert(v0 * v3 + v0 * v3 == 2 * (v0 * v3));
+        assert(v0 * v4 + v0 * v4 == 2 * (v0 * v4));
+        assert(v1 * v2 + v1 * v2 == 2 * (v1 * v2));
+        assert(v1 * v3 + v1 * v3 == 2 * (v1 * v3));
+        assert(v1 * v4 + v1 * v4 == 2 * (v1 * v4));
+        assert(v2 * v3 + v2 * v3 == 2 * (v2 * v3));
+        assert(v2 * v4 + v2 * v4 == 2 * (v2 * v4));
+        assert(v3 * v4 + v3 * v4 == 2 * (v3 * v4));
+    }
+
+    // This is the explicit version, now we can take everything mod p
+
+    // p well defined
+    pow255_gt_19();
+
+    // By definition, p = s^5 - 19
+    // equivalently,
+    // s^5 = (p + 19)
+    // s^6 = s * (p + 19)
+    // s^7 = s^2 * (p + 19)
+    // s^8 = s^3 * (p + 19)
+    assert(s5 == (p() + 19));
+
+    // we pack together terms to slim down expressions;
+
+    let c0_base = v0 *  v0;
+    let c0_x19 = 2 * (v2 * v3) + 2 * (v1 * v4);
+    let c0 = c0_base + 19 * c0_x19;
+
+    let c1_base = 2 * (v0 *  v1);
+    let c1_x19 = v3 * v3 + 2 * (v2 * v4);
+    let c1 = c1_base + 19 * c1_x19;
+
+    let c2_base = v1 * v1 + 2 * (v0 *  v2);
+    let c2_x19 = 2 * (v3 * v4);
+    let c2 = c2_base + 19 * c2_x19;
+
+    let c3_base = 2 * (v1 *  v2) + 2 * (v0 *  v3);
+    let c3_x19 = v4 * v4;
+    let c3 = c3_base + 19 * c3_x19;
+
+    let c4 = v2 *  v2 + 2 * (v1 *  v3) + 2 * (v0 *  v4);
+
+    // group in preparation for the substitution
+    assert(as_nat(v) * as_nat(v) ==
+        s4 * c4 +
+        s3 * (s5 * c3_x19 + c3_base) +
+        s2 * (s5 * c2_x19 + c2_base) +
+        s1 * (s5 * c1_x19 + c1_base) +
+             (s5 * c0_x19 + c0_base)
+    ) by {
+        broadcast use lemma_mul_is_distributive_add;
+        broadcast use lemma_mul_is_associative;
+    }
+
+    // Next we use the identity s5 = p + 19
+    assert(s5 * c3_x19 + c3_base == p() * c3_x19 + c3) by {
+        lemma_mul_is_distributive_add(c3_x19 as int, p() as int, 19);
+    }
+
+    assert(s5 * c2_x19 + c2_base == p() * c2_x19 + c2) by {
+        lemma_mul_is_distributive_add(c2_x19 as int, p() as int, 19);
+    }
+
+    assert(s5 * c1_x19 + c1_base == p() * c1_x19 + c1) by {
+        lemma_mul_is_distributive_add(c1_x19 as int, p() as int, 19);
+    }
+
+    assert(s5 * c0_x19 + c0_base == p() * c0_x19 + c0) by {
+        lemma_mul_is_distributive_add(c0_x19 as int, p() as int, 19);
+    }
+
+    // in summary, we can reorder and regroup terns to get X * p() + Y
+    assert(as_nat(v) * as_nat(v) ==
+        p() * ( s3 * c3_x19 + s2 * c2_x19 + s1 * c1_x19 + c0_x19 ) +
+        (
+            s4 * c4 +
+            s3 * c3 +
+            s2 * c2 +
+            s1 * c1 +
+                 c0
+        )
+    ) by {
+        broadcast use lemma_mul_is_distributive_add;
+        // we don't broadcast assoc, too many trigger matches
+        lemma_mul_is_associative(s3 as int, p() as int, c3_x19 as int);
+        lemma_mul_is_associative(s2 as int, p() as int, c2_x19 as int);
+        lemma_mul_is_associative(s1 as int, p() as int, c1_x19 as int);
+        lemma_mul_is_associative(p() as int, s3 as int, c3_x19 as int);
+        lemma_mul_is_associative(p() as int, s2 as int, c2_x19 as int);
+        lemma_mul_is_associative(p() as int, s1 as int, c1_x19 as int);
+    }
+
+
+    let k = ( s3 * c3_x19 + s2 * c2_x19 + s1 * c1_x19 + c0_x19 );
+    let sum = (
+            s4 * c4 +
+            s3 * c3 +
+            s2 * c2 +
+            s1 * c1 +
+                 c0
+        );
+
+    assert(as_nat(v) * as_nat(v) == k * p() + sum);
+    assert(k * p() + sum == (k as nat) * p() + (sum as nat));
+
+    // // Now, we simply move to mod p
+    // assert( (k * p() + sum) % p() == sum % p());
+
+    assert((as_nat(v) * as_nat(v)) % p() == ((k as nat) * p() + (sum as nat)) % p() );
+    assert(
+        ((k as nat) * p() + (sum as nat)) % p() ==
+        (sum as nat) % p()
+    ) by {
+        lemma_mod_sum_factor(k as int, sum as int, p() as int);
+    }
+
+    // sanity check
+    assert(s4 * c4 == pow2(4 * 51) * (v[2] * v[2] + 2 * (v[1] * v[3]) + 2 * (v[0] * v[4])));
+    assert(s3 * c3 == pow2(3 * 51) * (2 * (v[1] *  v[2]) + 2 * (v[0] *  v[3]) + 19 * (v[4] * v[4])));
+    assert(s2 * c2 == pow2(2 * 51) * (v[1] * v[1] + 2 * (v[0] *  v[2]) + 19 * (2 * (v[3] * v[4]))));
+    assert(s1 * c1 == pow2(1 * 51) * (2 * (v[0] *  v[1]) + 19 * (v[3] * v[3] + 2 * (v[2] * v[4]))));
+    assert(c0 == (v[0] *  v[0] + 19 * (2 * (v[2] * v[3]) + 2 * (v[1] * v[4]))));
+}
+
 // dummy, so we can call `verus`
 fn main() {}
 

--- a/curve25519-dalek/src/backend/serial/u64/mod.rs
+++ b/curve25519-dalek/src/backend/serial/u64/mod.rs
@@ -37,3 +37,6 @@ pub mod subtle_assumes;
 pub mod scalar_lemmas;
 
 pub mod scalar_specs;
+
+// Placeholder
+pub mod vstd_u128;

--- a/curve25519-dalek/src/backend/serial/u64/vstd_u128.rs
+++ b/curve25519-dalek/src/backend/serial/u64/vstd_u128.rs
@@ -1,0 +1,101 @@
+#![allow(unused)]
+use vstd::arithmetic::div_mod::*;
+use vstd::arithmetic::mul::*;
+use vstd::arithmetic::power2::*;
+use vstd::bits::*;
+use vstd::prelude::*;
+
+use vstd::calc_macro::*;
+
+// Placeholder until u128 lemma gets into vstd;
+verus! {
+
+macro_rules! lemma_pow2_no_overflow {
+    ($name:ident, $uN:ty) => {
+        verus! {
+        pub broadcast proof fn $name(n: nat)
+            requires
+                0 <= n < <$uN>::BITS,
+            ensures
+                0 < #[trigger] pow2(n) < <$uN>::MAX,
+        {
+            lemma_pow2_pos(n);
+            lemma2_to64();
+            lemma2_to64_rest();
+        }
+        }
+    };
+}
+
+lemma_pow2_no_overflow!(lemma_u128_pow2_no_overflow, u128);
+
+macro_rules! lemma_low_bits_mask_is_mod {
+    ($name:ident, $and_split_low_bit:ident, $no_overflow:ident, $uN:ty) => {
+        verus! {
+        pub broadcast proof fn $name(x: $uN, n: nat)
+            requires
+                n < <$uN>::BITS,
+            ensures
+                #[trigger] (x & (low_bits_mask(n) as $uN)) == x % (pow2(n) as $uN),
+            decreases n,
+        {
+            // Bounds.
+            $no_overflow(n);
+            lemma_pow2_pos(n);
+
+            // Inductive proof.
+            if n == 0 {
+                assert(low_bits_mask(0) == 0) by (compute_only);
+                assert(x & 0 == 0) by (bit_vector);
+                assert(pow2(0) == 1) by (compute_only);
+                assert(x % 1 == 0);
+            } else {
+                lemma_pow2_unfold(n);
+                assert((x % 2) == ((x % 2) & 1)) by (bit_vector);
+                calc!{ (==)
+                    x % (pow2(n) as $uN);
+                        {}
+                    x % ((2 * pow2((n-1) as nat)) as $uN);
+                        {
+                            lemma_pow2_pos((n-1) as nat);
+                            lemma_mod_breakdown(x as int, 2, pow2((n-1) as nat) as int);
+                        }
+                    add(mul(2, (x / 2) % (pow2((n-1) as nat) as $uN)), x % 2);
+                        {
+                            $name(x/2, (n-1) as nat);
+                        }
+                    add(mul(2, (x / 2) & (low_bits_mask((n-1) as nat) as $uN)), x % 2);
+                        {
+                            lemma_low_bits_mask_div2(n);
+                        }
+                    add(mul(2, (x / 2) & (low_bits_mask(n) as $uN / 2)), x % 2);
+                        {
+                            lemma_low_bits_mask_is_odd(n);
+                        }
+                    add(mul(2, (x / 2) & (low_bits_mask(n) as $uN / 2)), (x % 2) & ((low_bits_mask(n) as $uN) % 2));
+                        {
+                            $and_split_low_bit(x as $uN, low_bits_mask(n) as $uN);
+                        }
+                    x & (low_bits_mask(n) as $uN);
+                }
+            }
+        }
+
+        // Helper lemma breaking a bitwise-and operation into the low bit and the rest.
+        proof fn $and_split_low_bit(x: $uN, m: $uN)
+            by (bit_vector)
+            ensures
+                x & m == add(mul(((x / 2) & (m / 2)), 2), (x % 2) & (m % 2)),
+        {
+        }
+        }
+    };
+}
+
+lemma_low_bits_mask_is_mod!(
+    lemma_u128_low_bits_mask_is_mod,
+    lemma_u128_and_split_low_bit,
+    lemma_u128_pow2_no_overflow,
+    u128
+);
+}


### PR DESCRIPTION
This proof is quite lengthy, and I've done my best to structure comments/asserts such that it remains readable.

One noteworthy change made is the substitution of the 
```rust

loop {
  ...
  k -= 1
  if (k == 0) break
}
```
loop with 
```rust
for i in 0..k
```
This lets us reference the running loop counter for the loop invariant (`old(k)` did not work for the "mut-but-not-reference" parameter `k`).

It also introduces another `u128` lemma variant of a `vstd` lemma, so the next step is to try and get that integrated into `vstd`, so that we can remove the placeholder file `vstd_u128`.