### PR TITLE
Factoring out data boundaries in `pow2k`

### DIFF
--- a/curve25519-dalek/src/backend/serial/u64/field_lemmas.rs
+++ b/curve25519-dalek/src/backend/serial/u64/field_lemmas.rs
@@ -27,6 +27,8 @@ pub proof fn pow255_gt_19()
     lemma_pow2_strictly_increases(5, 255);
 }
 
+pub open spec const mask51: u64 = 2251799813685247u64;
+
 // Specialization for b = 51
 pub proof fn lemma_two_factoring_51(k : nat, ai: u64)
     ensures
@@ -691,6 +693,156 @@ pub proof fn lemma_mul_sub(ci: int, cj: int, cj_0: int, k: nat)
     // 2^(k + 51) * (cj - cj_0) = 2^(k + 51) * cj - 2^(k + 51) * cj_0
     lemma_mul_is_distributive_sub(pow2(k + 51) as int, cj, cj_0);
 }
+
+pub proof fn term_product_bounds(a: [u64; 5], bound: u64)
+    requires
+        19 * bound <= u64::MAX,
+        forall |i: int| 0 <= i < 5 ==> a[i] < bound
+    ensures
+        // c0
+        (a[0] as u128) * (a[0] as u128) < bound * bound,
+        (a[1] as u128) * ((19 * a[4]) as u128) < 19 * (bound * bound),
+        (a[2] as u128) * ((19 * a[3]) as u128) < 19 * (bound * bound),
+        // c1
+        (a[3] as u128) * ((19 * a[3]) as u128) < 19 * (bound * bound),
+        (a[0] as u128) * (a[1] as u128) < (bound * bound),
+        (a[2] as u128) * ((19 * a[4]) as u128) < 19 * (bound * bound),
+        // c2
+        (a[1] as u128) * (a[1] as u128) < (bound * bound),
+        (a[0] as u128) * (a[2] as u128) < (bound * bound),
+        (a[4] as u128) * ((19 * a[3]) as u128) < 19 * (bound * bound),
+        // c3
+        (a[4] as u128) * ((19 * a[4]) as u128) < 19 * (bound * bound),
+        (a[0] as u128) * (a[3] as u128) < (bound * bound),
+        (a[1] as u128) * (a[2] as u128) < (bound * bound),
+        // c4
+        (a[2] as u128) * (a[2] as u128) < (bound * bound),
+        (a[0] as u128) * (a[4] as u128) < (bound * bound),
+        (a[1] as u128) * (a[3] as u128) < (bound * bound)
+{
+    let bound19 = (19 * bound) as u64;
+
+    let a3_19 = (19 * a[3]) as u64;
+    let a4_19 = (19 * a[4]) as u64;
+
+    assert(bound * (19 * bound) == 19 * (bound * bound)) by {
+        lemma_mul_is_associative(19, bound as int, bound as int);
+    }
+
+    // c0
+    lemma_m(a[0], a[0], bound, bound);
+    lemma_m(a[1], a4_19, bound, bound19);
+    lemma_m(a[2], a3_19, bound, bound19);
+
+    // c1
+    lemma_m(a[3], a3_19, bound, bound19);
+    lemma_m(a[0],  a[1], bound, bound);
+    lemma_m(a[2], a4_19, bound, bound19);
+
+    // c2
+    lemma_m(a[1],  a[1], bound, bound);
+    lemma_m(a[0],  a[2], bound, bound);
+    lemma_m(a[4], a3_19, bound, bound19);
+
+    // c3
+    lemma_m(a[4], a4_19, bound, bound19);
+    lemma_m(a[0],  a[3], bound, bound);
+    lemma_m(a[1],  a[2], bound, bound);
+
+    // c4
+    lemma_m(a[2],  a[2], bound, bound);
+    lemma_m(a[0],  a[4], bound, bound);
+    lemma_m(a[1],  a[3], bound, bound);
+}
+
+pub open spec fn c0_0_val(a: [u64; 5]) -> u128 {
+    (a[0] *  a[0] + 2*( a[1] * (19 * a[4]) + a[2] * (19 * a[3]))) as u128
+}
+pub open spec fn c1_0_val(a: [u64; 5]) -> u128 {
+    (a[3] *  (19 * a[3]) + 2 *( a[0] * a[1] + a[2] * (19 * a[4]))) as u128
+}
+pub open spec fn c2_0_val(a: [u64;5]) -> u128{
+    (a[1] *  a[1] + 2*( a[0] *  a[2] + a[4] * (19 * a[3]))) as u128
+}
+pub open spec fn c3_0_val(a: [u64;5]) -> u128{
+    (a[4] * (19 * a[4]) + 2*( a[0] *  a[3] + a[1] * a[2])) as u128
+}
+pub open spec fn c4_0_val(a: [u64;5]) -> u128{
+    (a[2] *  a[2] + 2*( a[0] *  a[4] + a[1] *  a[3])) as u128
+}
+
+pub proof fn c_i_0_bounded(a: [u64; 5], bound: u64)
+    requires
+        19 * bound <= u64::MAX,
+        forall |i: int| 0 <= i < 5 ==> a[i] < bound
+    ensures
+        c0_0_val(a) < 77 * (bound * bound),
+        c1_0_val(a) < 59 * (bound * bound),
+        c2_0_val(a) < 41 * (bound * bound),
+        c3_0_val(a) < 23 * (bound * bound),
+        c4_0_val(a) <  5 * (bound * bound)
+{
+    term_product_bounds(a, bound);
+}
+
+pub open spec fn c0_val(a: [u64; 5]) -> u128 {
+    c0_0_val(a)
+}
+pub open spec fn c1_val(a: [u64; 5]) -> u128 {
+    (c1_0_val(a) + ((c0_val(a) >> 51) as u64) as u128) as u128
+}
+pub open spec fn c2_val(a: [u64;5]) -> u128{
+    (c2_0_val(a) + ((c1_val(a) >> 51) as u64) as u128) as u128
+}
+pub open spec fn c3_val(a: [u64;5]) -> u128{
+    (c3_0_val(a) + ((c2_val(a) >> 51) as u64) as u128) as u128
+}
+pub open spec fn c4_val(a: [u64;5]) -> u128{
+    (c4_0_val(a) + ((c3_val(a) >> 51) as u64) as u128) as u128
+}
+
+pub proof fn c_i_shift_bounded(a: [u64; 5], bound: u64)
+    requires
+        19 * bound <= u64::MAX,
+        77 * (bound * bound) + u64::MAX <= ((u64::MAX as u128) << 51),
+        forall |i: int| 0 <= i < 5 ==> a[i] < bound
+    ensures
+        (c0_val(a) >> 51) <= (u64::MAX as u128),
+        (c1_val(a) >> 51) <= (u64::MAX as u128),
+        (c2_val(a) >> 51) <= (u64::MAX as u128),
+        (c3_val(a) >> 51) <= (u64::MAX as u128),
+        (c4_val(a) >> 51) <= (u64::MAX as u128)
+
+{
+    c_i_0_bounded(a, bound);
+
+    lemma_shr_51_fits_u64(c0_val(a));
+    lemma_shr_51_fits_u64(c1_val(a));
+    lemma_shr_51_fits_u64(c2_val(a));
+    lemma_shr_51_fits_u64(c3_val(a));
+    lemma_shr_51_fits_u64(c4_val(a));
+}
+
+pub open spec fn carry_val(a: [u64; 5]) -> u64 {
+    (c4_val(a) >> 51) as u64
+}
+
+pub open spec fn a0_0_val(a: [u64; 5]) -> u64 {
+    (c0_val(a) as u64) & mask51
+}
+pub open spec fn a1_0_val(a: [u64; 5]) -> u64 {
+    (c1_val(a) as u64) & mask51
+}
+pub open spec fn a2_0_val(a: [u64; 5]) -> u64 {
+    (c2_val(a) as u64) & mask51
+}
+pub open spec fn a3_0_val(a: [u64; 5]) -> u64 {
+    (c3_val(a) as u64) & mask51
+}
+pub open spec fn a4_0_val(a: [u64; 5]) -> u64 {
+    (c4_val(a) as u64) & mask51
+}
+
 
 // dummy, so we can call `verus`
 fn main() {}

--- a/curve25519-dalek/src/backend/serial/u64/field_verus.rs
+++ b/curve25519-dalek/src/backend/serial/u64/field_verus.rs
@@ -819,32 +819,23 @@ impl FieldElement51 {
                 assert((c4 >> 51) <= (u64::MAX as u128));
 
                 let a0_0 = (c0_0 as u64) & LOW_51_BIT_MASK;
-
                 // a0_0 < (1u64 << 51)
                 masked_lt_51(c0_0 as u64);
 
                 let a1_0 = (c1 as u64) & LOW_51_BIT_MASK;
-
-                lemma_shr_51_fits_u64(c2);
                 // a1_0 < (1u64 << 51)
                 masked_lt_51(c1 as u64);
 
-
                 let a2 = (c2 as u64) & LOW_51_BIT_MASK;
-
-                lemma_shr_51_fits_u64(c3);
                 // a2 < (1u64 << 51)
                 masked_lt_51(c2 as u64);
 
-
                 let a3 = (c3 as u64) & LOW_51_BIT_MASK;
-
                 // a3 < (1u64 << 51)
                 masked_lt_51(c3 as u64);
 
                 let carry: u64 = (c4 >> 51) as u64;
                 let a4 = (c4 as u64) & LOW_51_BIT_MASK;
-
                 // a4 < (1u64 << 51)
                 masked_lt_51(c4 as u64);
 

--- a/curve25519-dalek/src/backend/serial/u64/field_verus.rs
+++ b/curve25519-dalek/src/backend/serial/u64/field_verus.rs
@@ -750,8 +750,27 @@ impl FieldElement51 {
                 let bound = 1u64 << 54;
                 let bound19 = (19 * bound) as u64;
                 let bound_sq = 1u128 << 108;
+
                 // u64 to u128 conversion forces extra assert
                 assert( (1u64 << 54) * ((19 * (1u64 << 54)) as u64) == 19 * (1u128 << 108)) by (bit_vector);
+                assert(((1u64 << 54) as u128) * ((1u64 << 54) as u128) == (1u128 << 108)) by (bit_vector);
+
+                // precond for term_product_bounds
+                assert( 19 * bound <= u64::MAX) by {
+                    assert( 19 * (1u64 << 54) <= u64::MAX) by (compute);
+                }
+                // If a[i] < 2^54 then a[i] * a[j] < 2^108 and a[i] * (19 * a[j]) < 19 * 2^108
+                term_product_bounds(a, bound);
+
+                // ci_0 < 77 * (1u128 << 108)
+                c_i_0_bounded(a, bound);
+
+                // precond for c_i_shift_bounded
+                assert(77 * (bound * bound) + u64::MAX <= ((u64::MAX as u128) << 51)) by {
+                    assert( 77 * (1u128 << 108)+ u64::MAX <= ((u64::MAX as u128) << 51)) by (compute);
+                }
+                // ci >> 51 <= u64::MAX
+                c_i_shift_bounded(a, bound);
 
                 // bv arithmetic
                 assert(19 < (1u64 << 5)) by (bit_vector);
@@ -759,81 +778,67 @@ impl FieldElement51 {
                 assert((1u64 << 52) < (1u64 << 54)) by (bit_vector);
                 assert((1u64 << 54) < (1u64 << 59)) by (bit_vector);
                 assert((1u64 << 54) * (1u64 << 5) == (1u64 << 59)) by (bit_vector);
-                assert(((1u64 << 54) as u128) * ((1u64 << 54) as u128) == (1u128 << 108)) by (bit_vector);
                 assert(((1u64 << 54) as u128) * ((1u64 << 59) as u128) == (1u128 << 113)) by (bit_vector);
 
                 let a3_19 = (19 * a[3]) as u64;
                 let a4_19 = (19 * a[4]) as u64;
 
-                // c0
-                let c0_0: u128 = (a[0] *  a[0] + 2*( a[1] * a4_19 + a[2] * a3_19)) as u128;
-                lemma_m(a[0], a[0], bound, bound);
-                lemma_m(a[1], a4_19, bound, bound19);
-                lemma_m(a[2], a3_19, bound, bound19);
-                // conclusion, (1 + 2 * (19 + 19)) = 77
+                // NOTE: we assert the properties derived from c_i_0_bounded
+                // and c_i_shift_bounded after every variable declaration,
+                // to trigger the solver instantiation
+
+                // ci_0 defs
+
+                let c0_0: u128 = c0_0_val(a); // a[0] *  a[0] + 2*( a[1] * a4_19 + a[2] * a3_19
                 assert(c0_0 < 77 * bound_sq);
 
-                // c1
-                let c1_0: u128 = (a[3] * a3_19 + 2*( a[0] *  a[1] + a[2] * a4_19)) as u128;
-                lemma_m(a[3], a3_19, bound, bound19);
-                lemma_m(a[0],  a[1], bound, bound);
-                lemma_m(a[2], a4_19, bound, bound19);
-                // conclusion, (19 + 2 * (1 + 19)) = 59
+                let c1_0: u128 = c1_0_val(a); // a[3] * a3_19 + 2*( a[0] *  a[1] + a[2] * a4_19
                 assert(c1_0 < 59 * bound_sq);
 
-                // c2
-                let c2_0: u128 = (a[1] *  a[1] + 2*( a[0] *  a[2] + a[4] * a3_19)) as u128;
-                lemma_m(a[1],  a[1], bound, bound);
-                lemma_m(a[0],  a[2], bound, bound);
-                lemma_m(a[4], a3_19, bound, bound19);
-                // conclusion, (1 + 2 * (1 + 19)) = 41
+                let c2_0: u128 = c2_0_val(a); // a[1] *  a[1] + 2*( a[0] *  a[2] + a[4] * a3_19
                 assert(c2_0 < 41 * bound_sq);
 
-                // c3
-                let c3_0: u128 = (a[4] * a4_19 + 2*( a[0] *  a[3] + a[1] *  a[2])) as u128;
-                lemma_m(a[4], a4_19, bound, bound19);
-                lemma_m(a[0],  a[3], bound, bound);
-                lemma_m(a[1],  a[2], bound, bound);
-                // conclusion, (19 + 2 * (1 + 1)) = 23
+                let c3_0: u128 =  c3_0_val(a); // a[4] * a4_19 + 2*( a[0] *  a[3] + a[1] *  a[2]
                 assert(c3_0 < 23 * bound_sq);
 
-                // c4
-                let c4_0: u128 = (a[2] *  a[2] + 2*( a[0] *  a[4] + a[1] *  a[3])) as u128;
-                lemma_m(a[2],  a[2], bound, bound);
-                lemma_m(a[0],  a[4], bound, bound);
-                lemma_m(a[1],  a[3], bound, bound);
-                // conclusion, (1 + 2 * (1 + 1)) = 5
+                let c4_0: u128 =  c4_0_val(a); // a[2] *  a[2] + 2*( a[0] *  a[4] + a[1] *  a[3]
                 assert(c4_0 < 5 * bound_sq);
 
-                assert( 77 * bound_sq <= ((u64::MAX as u128) << 51)) by (compute); // all ci_0 are then < MAX << 51
+                // ci defs
 
-                lemma_shr_51_fits_u64(c0_0);
+                let c1 = c1_val(a); // (c1_0 + ((c0_0 >> 51) as u64) as u128) as u128;
+                assert((c1 >> 51) <= (u64::MAX as u128));
 
-                let c1 = (c1_0 + ((c0_0 >> 51) as u64) as u128) as u128;
+                let c2 = c2_val(a); // (c2_0 + ((c1 >> 51) as u64) as u128) as u128;
+                assert((c2 >> 51) <= (u64::MAX as u128));
+
+                let c3 = c3_val(a); // (c3_0 + ((c2 >> 51) as u64) as u128) as u128;
+                assert((c3 >> 51) <= (u64::MAX as u128));
+
+                let c4 = c4_val(a); // (c4_0 + ((c3 >> 51) as u64) as u128) as u128;
+                assert((c4 >> 51) <= (u64::MAX as u128));
+
                 let a0_0 = (c0_0 as u64) & LOW_51_BIT_MASK;
 
-                lemma_shr_51_fits_u64(c1);
                 // a0_0 < (1u64 << 51)
                 masked_lt_51(c0_0 as u64);
 
-                let c2 = (c2_0 + ((c1 >> 51) as u64) as u128) as u128;
                 let a1_0 = (c1 as u64) & LOW_51_BIT_MASK;
 
                 lemma_shr_51_fits_u64(c2);
                 // a1_0 < (1u64 << 51)
                 masked_lt_51(c1 as u64);
 
-                let c3 = (c3_0 + ((c2 >> 51) as u64) as u128) as u128;
+
                 let a2 = (c2 as u64) & LOW_51_BIT_MASK;
 
                 lemma_shr_51_fits_u64(c3);
                 // a2 < (1u64 << 51)
                 masked_lt_51(c2 as u64);
 
-                let c4 = (c4_0 + ((c3 >> 51) as u64) as u128) as u128;
+
                 let a3 = (c3 as u64) & LOW_51_BIT_MASK;
 
-                lemma_shr_51_fits_u64(c4);
                 // a3 < (1u64 << 51)
                 masked_lt_51(c3 as u64);
 


### PR DESCRIPTION
No content changes, only rearranging lemmas and introducing new definitions breaking for e.g. `ci_0` terms as spec functions.

In general, proof refactoring is incredibly fragile; swapping the orders of `let`s and `asserts`, or removing known trivial asserts can often break the solver's ability to verify. As such, no further refactoring is planned for now.

Advice for future work: Try to minimize/avoid "global" asserts; the solver infers more than just what is user-specified, and might automatically infer critical lemmas invisible to the specifier. Instead, I would recommend heavy use of `assert ... by` within the top scope of a proof. That way, only the exact asserted statement should propagate, making it easier to keep track. In addition, each of _those_ could more easily be turned into a lemma (the assert statement is exactly the `ensures`) if needed.